### PR TITLE
refactor(tests): parallel cleanup of test-generation scaffolding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,15 +61,19 @@ Common scopes in this project:
 
 ```
 noir_IEEE754/
-├── Nargo.toml              # Noir project configuration
-├── src/
-│   ├── lib.nr              # Module exports and basic tests
-│   ├── float.nr            # IEEE 754 implementation
-│   └── ieee754_tests/      # Auto-generated test suite (~18k tests)
-│       ├── mod.nr          # Module declarations
-│       └── test_*/         # Test modules by source file
+├── Nargo.toml              # Workspace manifest
+├── ieee754/                # Core IEEE 754 implementation crate
+│   ├── Nargo.toml
+│   └── src/
+│       ├── lib.nr          # Module exports
+│       └── float.nr        # IEEE 754 implementation
+├── ieee754_unit_tests/     # Hand-written unit tests
+├── test_packages/          # Auto-generated test packages (gitignored, ~18k tests)
+│   └── ieee754_test_*/     # One Noir bin package per source .fptest file
 ├── scripts/
-│   └── generate_tests.py   # Test generation script
+│   ├── generate_tests.py   # Test generation script
+│   ├── regenerate_tests.sh # Regenerate the full test suite
+│   └── run_tests.py        # Run packages with optional filtering
 └── .ieee754_test_cache/    # Downloaded test files (gitignored)
 ```
 
@@ -86,52 +90,60 @@ The `scripts/generate_tests.py` script performs the following:
 3. **Converts operands to IEEE 754 bit patterns** handling normal, denormal, zero, infinity, and NaN values
 4. **Computes expected results using Python's IEEE 754 hardware** via the `struct` module — this ensures tests verify against actual IEEE 754 behavior rather than potentially inaccurate values in the test files
 5. **Generates Noir test functions** that call the implementation and assert against expected bit patterns
-6. **Organizes tests into chunks** of 25 tests per file for faster parallel compilation
+6. **Organises tests into separate Noir packages** (one per source `.fptest` file) with chunks of 25 tests per file for faster parallel compilation
 
-### Test File Structure
+### Test Package Structure
 
-Tests are organized hierarchically by source file, with each module split into 25-test chunks:
+Each source `.fptest` file becomes its own Noir bin package under `test_packages/`, with tests sharded into 25-test chunks. Files larger than `--max-tests-per-package` (default 1250) are split across multiple `_partN` packages.
 
 ```
-src/ieee754_tests/
-├── mod.nr                           # Top-level module declarations
-├── test_add_shift/
-│   ├── mod.nr                       # Chunk module declarations
-│   ├── chunk_0000.nr                # Tests 0-24
-│   ├── chunk_0001.nr                # Tests 25-49
-│   └── chunk_0002.nr                # Tests 50-56
-├── test_add_cancellation/
-│   └── chunk_0000.nr                # Tests 0-17
-├── test_add_cancellation_and_subnorm_result/
-│   ├── chunk_0000.nr - chunk_0012.nr  # ~313 tests
-│   └── ...
+test_packages/
+├── ieee754_test_add_shift/
+│   ├── Nargo.toml                   # Depends on ../../ieee754
+│   └── src/
+│       ├── main.nr                  # Module index + fn main()
+│       ├── chunk_0000.nr            # Tests 0-24
+│       ├── chunk_0001.nr            # Tests 25-49
+│       └── chunk_0002.nr            # Tests 50-56
+├── ieee754_test_add_cancellation/
+│   └── src/
+│       └── chunk_0000.nr            # Tests 0-17
+├── ieee754_test_add_shift_and_special_significands_part0/
+│   └── ...                          # Large file, split into multiple packages
 └── ...
 ```
 
-This chunking strategy enables faster compilation and allows running targeted subsets of the ~18,000 total tests.
+This per-package chunking strategy enables faster compilation and allows running targeted subsets of the ~18,000 total tests.
 
 ### Generating Tests
 
-The `generate_tests.py` script automatically downloads test files and generates Noir test code:
+The recommended path is `scripts/regenerate_tests.sh`, which wraps `generate_tests.py --all --packages`:
 
 ```bash
-# Generate tests from Add-Shift.fptest (default)
-python3 scripts/generate_tests.py -o src/ieee754_tests.nr
+# Regenerate the full test suite (all packages + CI matrix)
+./scripts/regenerate_tests.sh
+
+# Regenerate only the addition tests
+./scripts/regenerate_tests.sh --operation add
+```
+
+For finer-grained control you can call `generate_tests.py` directly:
+
+```bash
+# Generate all test files as separate Noir packages
+python3 scripts/generate_tests.py --all --packages --output-dir test_packages
 
 # Use specific test files
-python3 scripts/generate_tests.py --files Add-Shift.fptest Rounding.fptest -o src/ieee754_tests.nr
-
-# Generate tests from all available test files
-python3 scripts/generate_tests.py --all -o src/ieee754_tests.nr
+python3 scripts/generate_tests.py --files Add-Shift.fptest Rounding.fptest --packages --output-dir test_packages
 
 # List available test files
 python3 scripts/generate_tests.py --list
 
 # Filter by operation type
-python3 scripts/generate_tests.py --operation add --precision f32 -o src/ieee754_tests.nr
+python3 scripts/generate_tests.py --operation add --precision f32 --packages --output-dir test_packages
 
 # Clear cache and re-download
-python3 scripts/generate_tests.py --clear-cache -o src/ieee754_tests.nr
+python3 scripts/generate_tests.py --clear-cache --all --packages --output-dir test_packages
 ```
 
 ### Available Test Files
@@ -158,54 +170,56 @@ python3 scripts/generate_tests.py --clear-cache -o src/ieee754_tests.nr
 
 ### Running Tests
 
-> ⚠️ **Warning**: Running `nargo test` without filters executes ~18k tests and takes several hours. Always run individual chunks or modules during development.
+> ⚠️ **Warning**: Running every package executes ~18k tests and takes several hours. Use `scripts/run_tests.py` with a filter during development.
 
 ```bash
-# Run all tests from a specific test module (recommended)
-nargo test ieee754_tests::test_add_shift::
+# List available packages
+python3 scripts/run_tests.py --list
 
-# Run a specific chunk of tests (~25 tests, fastest iteration)
-nargo test ieee754_tests::test_add_shift::chunk_0000::
+# Run a single package (fastest iteration)
+python3 scripts/run_tests.py --package ieee754_test_add_shift
 
-# Run a single specific test
-nargo test ieee754_tests::test_add_shift::chunk_0000::test_f32_add_0
+# Run packages whose name matches a substring
+python3 scripts/run_tests.py add_shift
 
-# Run the manual unit tests only
-nargo test test_float32
-nargo test test_float64
+# Regenerate test packages, then run them
+python3 scripts/run_tests.py --generate
 
-# Run all tests (takes several hours)
-nargo test
+# Run only the hand-written unit tests
+nargo test --package ieee754_unit_tests
+
+# Run every package in the workspace (takes several hours)
+nargo test --workspace
 ```
 
-### Test Modules
+### Test Packages
 
-Tests are split into separate modules by source file, with each module further divided into chunks of 25 tests:
+Tests are split into separate Noir packages by source file, each package further divided into chunks of 25 tests. Source files exceeding `--max-tests-per-package` are split into multiple `_partN` packages.
 
-| Module | Source File | Test Count | Chunks |
+| Package | Source File | Test Count | Chunks |
 |--------|-------------|------------|--------|
-| `test_add_shift` | Add-Shift.fptest | 57 | 3 |
-| `test_add_cancellation` | Add-Cancellation.fptest | 18 | 1 |
-| `test_add_cancellation_and_subnorm_result` | Add-Cancellation-And-Subnorm-Result.fptest | 313 | 13 |
-| `test_add_shift_and_special_significands` | Add-Shift-And-Special-Significands.fptest | ~16k | ~640 |
-| `test_basic_types_inputs` | Basic-Types-Inputs.fptest | 882 | 36 |
-| `test_basic_types_intermediate` | Basic-Types-Intermediate.fptest | 40 | 2 |
-| `test_hamming_distance` | Hamming-Distance.fptest | 55 | 3 |
-| `test_overflow` | Overflow.fptest | 62 | 3 |
-| `test_rounding` | Rounding.fptest | 16 | 1 |
-| `test_underflow` | Underflow.fptest | 20 | 1 |
-| `test_vicinity_of_rounding_boundaries` | Vicinity-Of-Rounding-Boundaries.fptest | 31 | 2 |
+| `ieee754_test_add_shift` | Add-Shift.fptest | 57 | 3 |
+| `ieee754_test_add_cancellation` | Add-Cancellation.fptest | 18 | 1 |
+| `ieee754_test_add_cancellation_and_subnorm_result` | Add-Cancellation-And-Subnorm-Result.fptest | 313 | 13 |
+| `ieee754_test_add_shift_and_special_significands_part*` | Add-Shift-And-Special-Significands.fptest | ~16k | ~640 |
+| `ieee754_test_basic_types_inputs` | Basic-Types-Inputs.fptest | 882 | 36 |
+| `ieee754_test_basic_types_intermediate` | Basic-Types-Intermediate.fptest | 40 | 2 |
+| `ieee754_test_hamming_distance` | Hamming-Distance.fptest | 55 | 3 |
+| `ieee754_test_overflow` | Overflow.fptest | 62 | 3 |
+| `ieee754_test_rounding` | Rounding.fptest | 16 | 1 |
+| `ieee754_test_underflow` | Underflow.fptest | 20 | 1 |
+| `ieee754_test_vicinity_of_rounding_boundaries` | Vicinity-Of-Rounding-Boundaries.fptest | 31 | 2 |
 
 ## Submitting Changes
 
 Please ensure all tests pass before submitting PRs:
 
 ```bash
-# Generate full test suite
-python3 scripts/generate_tests.py --all -o src/ieee754_tests.nr
+# Regenerate the full test suite (packages + CI matrix)
+./scripts/regenerate_tests.sh
 
-# Run all tests
-nargo test
+# Run every package in the workspace (takes several hours)
+nargo test --workspace
 ```
 
 ## References

--- a/scripts/generate_tests.py
+++ b/scripts/generate_tests.py
@@ -704,6 +704,43 @@ def generate_noir_test_name(test: TestCase, index: int, force_f64: bool = False)
     return f"test_{precision}_{op}_{index}"
 
 
+def _compute_expected_bits(test: 'TestCase', f1: float, f2: float, is_float32: bool) -> tuple[int, bool]:
+    """Compute the expected result bits for this test case using Python's hardware float.
+
+    Returns (expected_bits, is_nan).
+    """
+    if test.result.is_nan:
+        expected = _FLOAT32_SPECIAL['qnan'] if is_float32 else _FLOAT64_SPECIAL['qnan']
+        return expected, True
+
+    if test.operation == Operation.ADD:
+        result_float = f1 + f2
+    elif test.operation == Operation.SUBTRACT:
+        result_float = f1 - f2
+    elif test.operation == Operation.MULTIPLY:
+        result_float = f1 * f2
+    elif test.operation == Operation.DIVIDE:
+        if f2 == 0:
+            # Division by zero — fall back to the test file's expected bits since
+            # Python raises ZeroDivisionError instead of producing IEEE Inf/NaN.
+            to_bits_result = fp_value_to_bits32 if is_float32 else fp_value_to_bits64
+            return to_bits_result(test.result), False
+        result_float = f1 / f2
+
+    if math.isnan(result_float):
+        expected = _FLOAT32_SPECIAL['qnan'] if is_float32 else _FLOAT64_SPECIAL['qnan']
+        return expected, True
+    if math.isinf(result_float):
+        if result_float > 0:
+            expected = _FLOAT32_SPECIAL['pos_inf'] if is_float32 else _FLOAT64_SPECIAL['pos_inf']
+        else:
+            expected = _FLOAT32_SPECIAL['neg_inf'] if is_float32 else _FLOAT64_SPECIAL['neg_inf']
+        return expected, False
+    if is_float32:
+        return float32_to_bits(result_float), False
+    return float64_to_bits(result_float), False
+
+
 def generate_noir_test(test: TestCase, index: int, add_debug: bool = False, force_f64: bool = False) -> Optional[str]:
     """Generate Noir test code for a single test case.
     
@@ -760,44 +797,7 @@ def generate_noir_test(test: TestCase, index: int, add_debug: bool = False, forc
     if not test.operand2.is_zero and f2 == 0:
         return None  # operand2 underflowed to zero (division by zero)
     
-    # Compute expected result using IEEE arithmetic
-    # This ensures the test verifies IEEE 754 compliance, not the test file's precision
-    result_is_nan = False
-    if test.result.is_nan:
-        result_is_nan = True
-        expected = _FLOAT32_SPECIAL['qnan'] if is_float32 else _FLOAT64_SPECIAL['qnan']
-    else:
-        # Compute result using Python (IEEE 754 compliant)
-        if test.operation == Operation.ADD:
-            result_float = f1 + f2
-        elif test.operation == Operation.SUBTRACT:
-            result_float = f1 - f2
-        elif test.operation == Operation.MULTIPLY:
-            result_float = f1 * f2
-        elif test.operation == Operation.DIVIDE:
-            if f2 == 0:
-                # Division by zero - use test file's expected result
-                to_bits_result = fp_value_to_bits32 if is_float32 else fp_value_to_bits64
-                expected = to_bits_result(test.result)
-            else:
-                result_float = f1 / f2
-        
-        if test.operation != Operation.DIVIDE or f2 != 0:
-            # Check for special results
-            if math.isnan(result_float):
-                result_is_nan = True
-                expected = _FLOAT32_SPECIAL['qnan'] if is_float32 else _FLOAT64_SPECIAL['qnan']
-            elif math.isinf(result_float):
-                if result_float > 0:
-                    expected = _FLOAT32_SPECIAL['pos_inf'] if is_float32 else _FLOAT64_SPECIAL['pos_inf']
-                else:
-                    expected = _FLOAT32_SPECIAL['neg_inf'] if is_float32 else _FLOAT64_SPECIAL['neg_inf']
-            else:
-                # Convert result to target precision bits
-                if is_float32:
-                    expected = float32_to_bits(result_float)
-                else:
-                    expected = float64_to_bits(result_float)
+    expected, result_is_nan = _compute_expected_bits(test, f1, f2, is_float32)
     
     # Determine the Noir function to call
     op_func_map = {

--- a/scripts/generate_tests.py
+++ b/scripts/generate_tests.py
@@ -93,277 +93,32 @@ KNOWN_BAD_TESTS = {
 
 def generate_synthetic_f64_tests() -> list['TestCase']:
     """Generate synthetic float64 test cases for corner cases.
-    
-    These tests cover the same categories as the IBM FPgen b32 tests but for f64:
-    - Corner rounding (denormal * denormal -> denormal/zero)
-    - Underflow transitions
-    - Hamming distance edge cases
-    - Sticky bit calculations
-    - Division trailing zeros
-    
-    Note: Uses a fixed seed (42) for reproducible/deterministic test generation.
+
+    Delegates to focused per-scenario generators. Uses a fixed seed (42)
+    so runs are deterministic; the seed is set once at the top so the
+    generators below share a single PRNG stream.
     """
-    random.seed(42)  # Reproducible tests - ensures deterministic test generation
-    
-    tests = []
-    
-    # Float64 constants
-    F64_BIAS = 1023
-    F64_MIN_EXP = -1022  # Minimum normal exponent
-    F64_MAX_EXP = 1023   # Maximum exponent
-    F64_MANTISSA_BITS = 52
-    F64_MIN_DENORM = 2**(-1074)  # Smallest positive denormal
-    F64_MIN_NORMAL = 2**(-1022)  # Smallest positive normal
-    
-    # Helper to create TestCase for f64
-    def make_f64_test(op: Operation, a_bits: int, b_bits: int, line_num: int, desc: str) -> 'TestCase':
-        a = float64_from_bits(a_bits)
-        b = float64_from_bits(b_bits)
-        
-        # Create FPValue from bits
-        def bits_to_fpvalue(bits: int) -> 'FPValue':
-            sign = (bits >> 63) & 1
-            exp = (bits >> 52) & 0x7FF
-            mant = bits & ((1 << 52) - 1)
-            
-            if exp == 0x7FF:
-                if mant == 0:
-                    return FPValue(sign=sign, significand="", exponent=0, is_inf=True)
-                else:
-                    return FPValue(sign=sign, significand="", exponent=0, is_nan=True)
-            elif exp == 0:
-                if mant == 0:
-                    return FPValue(sign=sign, significand="", exponent=0, is_zero=True)
-                else:
-                    # Denormal
-                    return FPValue(sign=sign, significand=f"0{mant:013X}", exponent=-1022)
-            else:
-                # Normal
-                return FPValue(sign=sign, significand=f"1{mant:013X}", exponent=exp - F64_BIAS)
-        
-        op1 = bits_to_fpvalue(a_bits)
-        op2 = bits_to_fpvalue(b_bits)
-        
-        # Compute expected result
-        result_float = 0.0
-        if op == Operation.ADD:
-            result_float = a + b
-        elif op == Operation.SUBTRACT:
-            result_float = a - b
-        elif op == Operation.MULTIPLY:
-            result_float = a * b
-        elif op == Operation.DIVIDE:
-            if b != 0:
-                result_float = a / b
-        
-        result_bits = float64_to_bits(result_float)
-        result_val = bits_to_fpvalue(result_bits)
-        
-        return TestCase(
-            precision=Precision.BINARY64,
-            operation=op,
-            rounding=RoundingMode.NEAREST_EVEN,
-            operand1=op1,
-            operand2=op2,
-            operand3=None,
-            result=result_val,
-            exception_flags="",
-            line_number=line_num,
-            raw_line=f"synthetic_f64 {desc}"
-        )
-    
-    line_num = 0
-    
-    # ========== Corner Rounding Tests (like b32 Corner-Rounding.fptest) ==========
-    # These test denormal * denormal -> zero/tiny denormal transitions
-    
-    # Smallest denormals multiplied
-    for i in range(20):
-        # Very small denormals that multiply to zero or smallest denormal
-        a_mant = random.randint(1, 0xFFFF)  # Small mantissa
-        b_mant = random.randint(1, 0xFFFF)
-        a_bits = a_mant  # Denormal (exp=0)
-        b_bits = b_mant
-        if random.random() < 0.5:
-            a_bits |= (1 << 63)  # Negative
-        if random.random() < 0.5:
-            b_bits |= (1 << 63)
-        tests.append(make_f64_test(Operation.MULTIPLY, a_bits, b_bits, line_num, f"corner_mul_denorm_{i}"))
-        line_num += 1
-    
-    # Division with denormals
-    for i in range(20):
-        # Denormal / large number -> zero
-        a_mant = random.randint(1, 0xFFFFFFFFFFF)
-        a_bits = a_mant  # Denormal
-        # Large divisor
-        b_exp = random.randint(900, 1023)
-        b_mant = random.randint(0, (1 << 52) - 1)
-        b_bits = (b_exp << 52) | b_mant
-        if random.random() < 0.5:
-            a_bits |= (1 << 63)
-        if random.random() < 0.5:
-            b_bits |= (1 << 63)
-        tests.append(make_f64_test(Operation.DIVIDE, a_bits, b_bits, line_num, f"corner_div_denorm_{i}"))
-        line_num += 1
-    
-    # ========== Underflow Tests ==========
-    # Numbers that underflow from normal to denormal
-    for i in range(30):
-        # Small normal * small normal -> denormal
-        a_exp = random.randint(1, 50)  # Very small normal exponent
-        b_exp = random.randint(1, 50)
-        a_mant = random.randint(0, (1 << 52) - 1)
-        b_mant = random.randint(0, (1 << 52) - 1)
-        a_bits = (a_exp << 52) | a_mant
-        b_bits = (b_exp << 52) | b_mant
-        if random.random() < 0.5:
-            a_bits |= (1 << 63)
-        if random.random() < 0.5:
-            b_bits |= (1 << 63)
-        tests.append(make_f64_test(Operation.MULTIPLY, a_bits, b_bits, line_num, f"underflow_mul_{i}"))
-        line_num += 1
-    
-    # Division underflow
-    for i in range(20):
-        # Small normal / large normal -> denormal
-        a_exp = random.randint(1, 100)
-        b_exp = random.randint(1500, 2046)
-        a_mant = random.randint(0, (1 << 52) - 1)
-        b_mant = random.randint(0, (1 << 52) - 1)
-        a_bits = (a_exp << 52) | a_mant
-        b_bits = (b_exp << 52) | b_mant
-        if random.random() < 0.5:
-            a_bits |= (1 << 63)
-        if random.random() < 0.5:
-            b_bits |= (1 << 63)
-        tests.append(make_f64_test(Operation.DIVIDE, a_bits, b_bits, line_num, f"underflow_div_{i}"))
-        line_num += 1
-    
-    # ========== Hamming Distance Tests ==========
-    # Adjacent values that differ by 1 ULP
-    for i in range(30):
-        # Create a value and add/subtract 1 ULP
-        exp = random.randint(1, 2046)
-        mant = random.randint(1, (1 << 52) - 2)
-        base_bits = (exp << 52) | mant
-        ulp_bits = base_bits + 1  # 1 ULP higher
-        
-        base = float64_from_bits(base_bits)
-        ulp = float64_from_bits(ulp_bits)
-        diff = ulp - base  # This is 1 ULP
-        
-        # Test addition of values that result in 1 ULP difference
-        a_bits = float64_to_bits(base)
-        b_bits = float64_to_bits(diff)
-        tests.append(make_f64_test(Operation.ADD, a_bits, b_bits, line_num, f"hamming_add_{i}"))
-        line_num += 1
-        
-        # Subtraction test
-        tests.append(make_f64_test(Operation.SUBTRACT, float64_to_bits(ulp), b_bits, line_num, f"hamming_sub_{i}"))
-        line_num += 1
-    
-    # ========== Sticky Bit Tests ==========
-    # Values where sticky bit affects rounding
-    for i in range(30):
-        # Create values where intermediate result has sticky bits
-        exp_a = random.randint(500, 1500)
-        exp_b = random.randint(500, 1500)
-        mant_a = random.randint((1 << 51), (1 << 52) - 1)  # Ensure many bits set
-        mant_b = random.randint((1 << 51), (1 << 52) - 1)
-        a_bits = (exp_a << 52) | mant_a
-        b_bits = (exp_b << 52) | mant_b
-        if random.random() < 0.5:
-            a_bits |= (1 << 63)
-        if random.random() < 0.5:
-            b_bits |= (1 << 63)
-        tests.append(make_f64_test(Operation.MULTIPLY, a_bits, b_bits, line_num, f"sticky_mul_{i}"))
-        line_num += 1
-    
-    # ========== Division Trailing Zeros Tests ==========
-    # Division that results in exact values (no rounding needed)
-    for i in range(20):
-        # Powers of 2 division
-        exp_a = random.randint(100, 1900)
-        exp_b = random.randint(100, 1900)
-        a_bits = exp_a << 52  # 1.0 * 2^(exp-1023)
-        b_bits = exp_b << 52
-        if random.random() < 0.5:
-            a_bits |= (1 << 63)
-        if random.random() < 0.5:
-            b_bits |= (1 << 63)
-        tests.append(make_f64_test(Operation.DIVIDE, a_bits, b_bits, line_num, f"div_pow2_{i}"))
-        line_num += 1
-    
-    # ========== Rounding Boundary Tests ==========
-    # Values exactly at rounding boundaries
-    for i in range(30):
-        # Create values that are exactly at a rounding boundary (guard bit = 1, round = 0, sticky = 0)
-        exp = random.randint(100, 1900)
-        # Mantissa with specific bit pattern for rounding
-        mant = random.randint(0, (1 << 48) - 1) << 4  # Clear low 4 bits
-        mant |= 0x8  # Set guard bit exactly at midpoint
-        a_bits = (exp << 52) | mant
-        b_bits = (1023 << 52)  # 1.0
-        tests.append(make_f64_test(Operation.MULTIPLY, a_bits, b_bits, line_num, f"round_boundary_{i}"))
-        line_num += 1
-    
-    # ========== Overflow Boundary Tests ==========
-    for i in range(20):
-        # Large values that multiply to near-overflow
-        exp_a = random.randint(1800, 2046)
-        exp_b = random.randint(1, 300)
-        mant_a = random.randint(0, (1 << 52) - 1)
-        mant_b = random.randint(0, (1 << 52) - 1)
-        a_bits = (exp_a << 52) | mant_a
-        b_bits = (exp_b << 52) | mant_b
-        tests.append(make_f64_test(Operation.MULTIPLY, a_bits, b_bits, line_num, f"overflow_mul_{i}"))
-        line_num += 1
-    
-    # ========== Denormal Input Normalization Tests ==========
-    # These specifically test the denormal normalization path (like the float32 fixes)
-    for i in range(30):
-        # Denormal with specific leading bit positions
-        leading_pos = random.randint(0, 51)
-        mant = (1 << leading_pos) | random.randint(0, (1 << leading_pos) - 1)
-        a_bits = mant  # Denormal
-        
-        # Multiply by a normal value
-        b_exp = random.randint(1, 100)
-        b_mant = random.randint(0, (1 << 52) - 1)
-        b_bits = (b_exp << 52) | b_mant
-        if random.random() < 0.5:
-            a_bits |= (1 << 63)
-        if random.random() < 0.5:
-            b_bits |= (1 << 63)
-        tests.append(make_f64_test(Operation.MULTIPLY, a_bits, b_bits, line_num, f"denorm_normalize_mul_{i}"))
-        line_num += 1
-        
-        # Division with denormal dividend
-        tests.append(make_f64_test(Operation.DIVIDE, a_bits, b_bits, line_num, f"denorm_normalize_div_{i}"))
-        line_num += 1
-    
-    # ========== Specific Known Problematic Patterns ==========
-    # These are patterns that were problematic for float32 and should be tested for float64
-    
-    # Denormal result that rounds up to normal
-    for i in range(10):
-        # Just below normal threshold
-        a_bits = 0x000FFFFFFFFFFFFF  # Largest denormal
-        b_exp = random.randint(1020, 1026)
-        b_mant = random.randint(0, (1 << 52) - 1)
-        b_bits = (b_exp << 52) | b_mant
-        tests.append(make_f64_test(Operation.MULTIPLY, a_bits, b_bits, line_num, f"denorm_to_normal_{i}"))
-        line_num += 1
-    
-    # Very small result that might incorrectly round to zero
-    for i in range(10):
-        a_bits = 0x0000000000000001  # Smallest denormal
-        b_exp = random.randint(1020, 1026)
-        b_bits = b_exp << 52
-        tests.append(make_f64_test(Operation.MULTIPLY, a_bits, b_bits, line_num, f"tiny_mul_{i}"))
-        line_num += 1
-    
+    random.seed(42)
+
+    generators = [
+        _gen_corner_mul_denorm,
+        _gen_corner_div_denorm,
+        _gen_underflow_mul,
+        _gen_underflow_div,
+        _gen_hamming_add_sub,
+        _gen_sticky_mul,
+        _gen_div_pow2,
+        _gen_round_boundary,
+        _gen_overflow_mul,
+        _gen_denorm_normalize,
+        _gen_denorm_to_normal,
+        _gen_tiny_mul,
+    ]
+
+    tests: list['TestCase'] = []
+    for generator in generators:
+        tests.extend(generator(len(tests)))
+
     print(f"Generated {len(tests)} synthetic f64 test cases")
     return tests
 
@@ -556,6 +311,268 @@ def fp_value_to_bits32(val: FPValue) -> int:
 def fp_value_to_bits64(val: FPValue) -> int:
     """Convert an FPValue to IEEE 754 binary64 bits."""
     return fp_value_to_bits(val, is_float32=False)
+
+
+# Float64 layout constants (used by synthetic-f64 generators below).
+_F64_BIAS = 1023
+_F64_SIGN_BIT = 1 << 63
+_F64_MANTISSA_MASK = (1 << 52) - 1
+
+
+def bits_to_fpvalue(bits: int) -> FPValue:
+    """Inverse of fp_value_to_bits for float64: decode IEEE 754 binary64 bits into an FPValue."""
+    sign = (bits >> 63) & 1
+    exp = (bits >> 52) & 0x7FF
+    mant = bits & _F64_MANTISSA_MASK
+
+    if exp == 0x7FF:
+        if mant == 0:
+            return FPValue(sign=sign, significand="", exponent=0, is_inf=True)
+        return FPValue(sign=sign, significand="", exponent=0, is_nan=True)
+    if exp == 0:
+        if mant == 0:
+            return FPValue(sign=sign, significand="", exponent=0, is_zero=True)
+        # Denormal: leading hex digit is 0 to indicate no implicit leading 1.
+        return FPValue(sign=sign, significand=f"0{mant:013X}", exponent=-1022)
+    # Normal: leading hex digit is 1 for the implicit bit.
+    return FPValue(sign=sign, significand=f"1{mant:013X}", exponent=exp - _F64_BIAS)
+
+
+def _random_sign_bit() -> int:
+    """Return the f64 sign-bit mask with 50/50 probability, else 0."""
+    return _F64_SIGN_BIT if random.random() < 0.5 else 0
+
+
+def _make_synthetic_f64_test(op: 'Operation', a_bits: int, b_bits: int, line_num: int, desc: str) -> 'TestCase':
+    """Build a synthetic float64 TestCase for ``a op b`` using IEEE 754 arithmetic on the host."""
+    a = float64_from_bits(a_bits)
+    b = float64_from_bits(b_bits)
+
+    result_float = 0.0
+    if op == Operation.ADD:
+        result_float = a + b
+    elif op == Operation.SUBTRACT:
+        result_float = a - b
+    elif op == Operation.MULTIPLY:
+        result_float = a * b
+    elif op == Operation.DIVIDE:
+        if b != 0:
+            result_float = a / b
+
+    result_bits = float64_to_bits(result_float)
+
+    return TestCase(
+        precision=Precision.BINARY64,
+        operation=op,
+        rounding=RoundingMode.NEAREST_EVEN,
+        operand1=bits_to_fpvalue(a_bits),
+        operand2=bits_to_fpvalue(b_bits),
+        operand3=None,
+        result=bits_to_fpvalue(result_bits),
+        exception_flags="",
+        line_number=line_num,
+        raw_line=f"synthetic_f64 {desc}",
+    )
+
+
+def _gen_corner_mul_denorm(start_line: int) -> list['TestCase']:
+    """Tiny denormal x denormal multiplications (corner-rounding to zero or smallest denormal)."""
+    tests = []
+    for i in range(20):
+        a_bits = random.randint(1, 0xFFFF) | _random_sign_bit()
+        b_bits = random.randint(1, 0xFFFF) | _random_sign_bit()
+        tests.append(_make_synthetic_f64_test(
+            Operation.MULTIPLY, a_bits, b_bits, start_line + i, f"corner_mul_denorm_{i}"
+        ))
+    return tests
+
+
+def _gen_corner_div_denorm(start_line: int) -> list['TestCase']:
+    """Denormal dividend / large normal divisor (drives result towards zero)."""
+    tests = []
+    for i in range(20):
+        a_bits = random.randint(1, 0xFFFFFFFFFFF) | _random_sign_bit()
+        b_exp = random.randint(900, 1023)
+        b_mant = random.randint(0, _F64_MANTISSA_MASK)
+        b_bits = (b_exp << 52) | b_mant | _random_sign_bit()
+        tests.append(_make_synthetic_f64_test(
+            Operation.DIVIDE, a_bits, b_bits, start_line + i, f"corner_div_denorm_{i}"
+        ))
+    return tests
+
+
+def _gen_underflow_mul(start_line: int) -> list['TestCase']:
+    """Small normal x small normal that underflows to a denormal product."""
+    tests = []
+    for i in range(30):
+        a_exp = random.randint(1, 50)
+        b_exp = random.randint(1, 50)
+        a_mant = random.randint(0, _F64_MANTISSA_MASK)
+        b_mant = random.randint(0, _F64_MANTISSA_MASK)
+        a_bits = (a_exp << 52) | a_mant | _random_sign_bit()
+        b_bits = (b_exp << 52) | b_mant | _random_sign_bit()
+        tests.append(_make_synthetic_f64_test(
+            Operation.MULTIPLY, a_bits, b_bits, start_line + i, f"underflow_mul_{i}"
+        ))
+    return tests
+
+
+def _gen_underflow_div(start_line: int) -> list['TestCase']:
+    """Small normal / large normal that underflows the quotient to a denormal."""
+    tests = []
+    for i in range(20):
+        a_exp = random.randint(1, 100)
+        b_exp = random.randint(1500, 2046)
+        a_mant = random.randint(0, _F64_MANTISSA_MASK)
+        b_mant = random.randint(0, _F64_MANTISSA_MASK)
+        a_bits = (a_exp << 52) | a_mant | _random_sign_bit()
+        b_bits = (b_exp << 52) | b_mant | _random_sign_bit()
+        tests.append(_make_synthetic_f64_test(
+            Operation.DIVIDE, a_bits, b_bits, start_line + i, f"underflow_div_{i}"
+        ))
+    return tests
+
+
+def _gen_hamming_add_sub(start_line: int) -> list['TestCase']:
+    """Adjacent values differing by 1 ULP: addition and subtraction (Hamming-distance edge cases)."""
+    tests = []
+    line_num = start_line
+    for i in range(30):
+        exp = random.randint(1, 2046)
+        mant = random.randint(1, (1 << 52) - 2)
+        base_bits = (exp << 52) | mant
+        ulp_bits = base_bits + 1
+
+        base = float64_from_bits(base_bits)
+        ulp = float64_from_bits(ulp_bits)
+        diff = ulp - base
+
+        a_bits = float64_to_bits(base) | _random_sign_bit()
+        b_bits = float64_to_bits(diff) | _random_sign_bit()
+        tests.append(_make_synthetic_f64_test(
+            Operation.ADD, a_bits, b_bits, line_num, f"hamming_add_{i}"
+        ))
+        line_num += 1
+
+        a_bits_sub = float64_to_bits(ulp) | _random_sign_bit()
+        b_bits_sub = float64_to_bits(diff) | _random_sign_bit()
+        tests.append(_make_synthetic_f64_test(
+            Operation.SUBTRACT, a_bits_sub, b_bits_sub, line_num, f"hamming_sub_{i}"
+        ))
+        line_num += 1
+    return tests
+
+
+def _gen_sticky_mul(start_line: int) -> list['TestCase']:
+    """Multiplications whose intermediate product has many low bits set (sticky-bit rounding)."""
+    tests = []
+    for i in range(30):
+        exp_a = random.randint(500, 1500)
+        exp_b = random.randint(500, 1500)
+        mant_a = random.randint((1 << 51), (1 << 52) - 1)
+        mant_b = random.randint((1 << 51), (1 << 52) - 1)
+        a_bits = (exp_a << 52) | mant_a | _random_sign_bit()
+        b_bits = (exp_b << 52) | mant_b | _random_sign_bit()
+        tests.append(_make_synthetic_f64_test(
+            Operation.MULTIPLY, a_bits, b_bits, start_line + i, f"sticky_mul_{i}"
+        ))
+    return tests
+
+
+def _gen_div_pow2(start_line: int) -> list['TestCase']:
+    """Division of pure powers of two (exact result, no rounding required)."""
+    tests = []
+    for i in range(20):
+        exp_a = random.randint(100, 1900)
+        exp_b = random.randint(100, 1900)
+        a_bits = (exp_a << 52) | _random_sign_bit()
+        b_bits = (exp_b << 52) | _random_sign_bit()
+        tests.append(_make_synthetic_f64_test(
+            Operation.DIVIDE, a_bits, b_bits, start_line + i, f"div_pow2_{i}"
+        ))
+    return tests
+
+
+def _gen_round_boundary(start_line: int) -> list['TestCase']:
+    """Operands whose mantissa sits exactly on a guard-bit rounding boundary."""
+    tests = []
+    for i in range(30):
+        exp = random.randint(100, 1900)
+        mant = random.randint(0, (1 << 48) - 1) << 4
+        mant |= 0x8  # Set the guard bit at the midpoint.
+        a_bits = (exp << 52) | mant | _random_sign_bit()
+        b_bits = (1023 << 52) | _random_sign_bit()  # +-1.0
+        tests.append(_make_synthetic_f64_test(
+            Operation.MULTIPLY, a_bits, b_bits, start_line + i, f"round_boundary_{i}"
+        ))
+    return tests
+
+
+def _gen_overflow_mul(start_line: int) -> list['TestCase']:
+    """Multiplications whose magnitude lands near the f64 overflow boundary."""
+    tests = []
+    for i in range(20):
+        exp_a = random.randint(1800, 2046)
+        exp_b = random.randint(1, 300)
+        mant_a = random.randint(0, _F64_MANTISSA_MASK)
+        mant_b = random.randint(0, _F64_MANTISSA_MASK)
+        a_bits = (exp_a << 52) | mant_a | _random_sign_bit()
+        b_bits = (exp_b << 52) | mant_b | _random_sign_bit()
+        tests.append(_make_synthetic_f64_test(
+            Operation.MULTIPLY, a_bits, b_bits, start_line + i, f"overflow_mul_{i}"
+        ))
+    return tests
+
+
+def _gen_denorm_normalize(start_line: int) -> list['TestCase']:
+    """Denormal inputs with varying leading-bit positions, exercising the normalisation path."""
+    tests = []
+    line_num = start_line
+    for i in range(30):
+        leading_pos = random.randint(0, 51)
+        mant = (1 << leading_pos) | random.randint(0, (1 << leading_pos) - 1)
+        a_bits = mant | _random_sign_bit()
+
+        b_exp = random.randint(1, 100)
+        b_mant = random.randint(0, _F64_MANTISSA_MASK)
+        b_bits = (b_exp << 52) | b_mant | _random_sign_bit()
+
+        tests.append(_make_synthetic_f64_test(
+            Operation.MULTIPLY, a_bits, b_bits, line_num, f"denorm_normalize_mul_{i}"
+        ))
+        line_num += 1
+        tests.append(_make_synthetic_f64_test(
+            Operation.DIVIDE, a_bits, b_bits, line_num, f"denorm_normalize_div_{i}"
+        ))
+        line_num += 1
+    return tests
+
+
+def _gen_denorm_to_normal(start_line: int) -> list['TestCase']:
+    """Largest denormal multiplied by values straddling the normal threshold."""
+    tests = []
+    for i in range(10):
+        a_bits = 0x000FFFFFFFFFFFFF | _random_sign_bit()
+        b_exp = random.randint(1020, 1026)
+        b_mant = random.randint(0, _F64_MANTISSA_MASK)
+        b_bits = (b_exp << 52) | b_mant | _random_sign_bit()
+        tests.append(_make_synthetic_f64_test(
+            Operation.MULTIPLY, a_bits, b_bits, start_line + i, f"denorm_to_normal_{i}"
+        ))
+    return tests
+
+
+def _gen_tiny_mul(start_line: int) -> list['TestCase']:
+    """Smallest denormal multiplied by values near 1.0 (must not flush to zero incorrectly)."""
+    tests = []
+    for i in range(10):
+        a_bits = 0x0000000000000001 | _random_sign_bit()
+        b_exp = random.randint(1020, 1026)
+        b_bits = (b_exp << 52) | _random_sign_bit()
+        tests.append(_make_synthetic_f64_test(
+            Operation.MULTIPLY, a_bits, b_bits, start_line + i, f"tiny_mul_{i}"
+        ))
+    return tests
 
 
 def parse_test_line(line: str, line_number: int) -> Optional[TestCase]:

--- a/scripts/generate_tests.py
+++ b/scripts/generate_tests.py
@@ -860,38 +860,27 @@ def analyze_test_code(test_code: list[str]) -> dict[str, bool]:
     }
 
 
-def generate_noir_header_from_analysis_for_package(source_info: str, analysis: dict[str, bool]) -> str:
-    """Generate Noir test file header with only required imports for separate packages."""
-    imports = [name for name, needed in analysis.items() if needed]
-    
-    # Sort imports for consistency
-    imports.sort()
+def _render_noir_header(source_info: str, analysis: dict[str, bool], use_path: str) -> str:
+    imports = sorted(name for name, needed in analysis.items() if needed)
     imports_str = ", ".join(imports)
-    
+
     return f"""// Auto-generated IEEE 754 test cases
 // Generated from: {source_info}
 // Test suite source: https://github.com/sergev/ieee754-test-suite
 
-use ieee754::float::{{{imports_str}}};
+use {use_path}::{{{imports_str}}};
 
 """
+
+
+def generate_noir_header_from_analysis_for_package(source_info: str, analysis: dict[str, bool]) -> str:
+    """Generate Noir test file header with only required imports for separate packages."""
+    return _render_noir_header(source_info, analysis, "ieee754::float")
 
 
 def generate_noir_header_from_analysis(source_info: str, analysis: dict[str, bool]) -> str:
     """Generate Noir test file header with only required imports."""
-    imports = [name for name, needed in analysis.items() if needed]
-    
-    # Sort imports for consistency
-    imports.sort()
-    imports_str = ", ".join(imports)
-    
-    return f"""// Auto-generated IEEE 754 test cases
-// Generated from: {source_info}
-// Test suite source: https://github.com/sergev/ieee754-test-suite
-
-use crate::float::{{{imports_str}}};
-
-"""
+    return _render_noir_header(source_info, analysis, "crate::float")
 
 
 def generate_noir_file(tests: list[TestCase], output_path: str, source_files: list[str], add_debug: bool = False, force_f64: bool = False):

--- a/scripts/generate_tests.py
+++ b/scripts/generate_tests.py
@@ -683,9 +683,14 @@ def parse_fptest_file(filepath: str) -> list[TestCase]:
     return tests
 
 
-def generate_noir_test_name(test: TestCase, index: int) -> str:
-    """Generate a Noir test function name for a test case."""
-    precision = "f32" if test.precision == Precision.BINARY32 else "f64"
+def generate_noir_test_name(test: TestCase, index: int, force_f64: bool = False) -> str:
+    """Generate a Noir test function name for a test case.
+
+    When force_f64 is True the name reflects the effective f64 precision
+    even if the source TestCase is f32.
+    """
+    is_f32 = test.precision == Precision.BINARY32 and not force_f64
+    precision = "f32" if is_f32 else "f64"
     op_names = {
         Operation.ADD: "add",
         Operation.SUBTRACT: "sub",
@@ -803,11 +808,7 @@ def generate_noir_test(test: TestCase, index: int, add_debug: bool = False, forc
     }
     op_func = op_func_map[test.operation]
     
-    # Format values - use modified test name for f64-converted tests
-    if force_f64 and original_is_f32:
-        test_name = f"test_f64_{op_func_map[test.operation]}_{index}"
-    else:
-        test_name = generate_noir_test_name(test, index)
+    test_name = generate_noir_test_name(test, index, force_f64=force_f64 and original_is_f32)
     bits1_str = f"0x{bits1:0{hex_width}X}"
     bits2_str = f"0x{bits2:0{hex_width}X}"
     expected_str = f"0x{expected:0{hex_width}X}"

--- a/scripts/generate_tests.py
+++ b/scripts/generate_tests.py
@@ -509,12 +509,15 @@ def fp_value_to_bits(val: FPValue, is_float32: bool = True) -> int:
         # Pad/truncate to exactly 6 hex digits
         frac_hex_padded = frac_hex.ljust(6, '0')[:6]
         frac_bits_24 = int(frac_hex_padded, 16)
-        # Round from 24 bits to 23 bits (round to nearest, ties to even)
+        # Round from 24 bits to 23 bits (round to nearest, ties to even).
+        # No sticky bits apply here: a 24-bit value rounded to 23 bits has no
+        # bits beyond the round bit, so the half-way tie reduces to "round up
+        # only when the LSB of the result is odd".
         lsb = (frac_bits_24 >> 1) & 1
         round_bit = frac_bits_24 & 1
         frac_bits_23 = frac_bits_24 >> 1
-        if round_bit and (lsb or (frac_bits_24 & 0)):  # round up
-            frac_bits_23 += round_bit
+        if round_bit and lsb:  # exact half, LSB odd -> round up to even
+            frac_bits_23 += 1
         mantissa = frac_bits_23 & 0x7FFFFF
     else:
         # Float64: 52-bit mantissa, 11-bit exponent (bias 1023)

--- a/scripts/generate_tests.py
+++ b/scripts/generate_tests.py
@@ -323,7 +323,13 @@ _F64_MANTISSA_MASK = (1 << 52) - 1
 
 
 def bits_to_fpvalue(bits: int) -> FPValue:
-    """Inverse of fp_value_to_bits for float64: decode IEEE 754 binary64 bits into an FPValue."""
+    """Decode IEEE 754 binary64 bits into an FPValue for synthetic-test scaffolding.
+
+    Lossy on NaN: any NaN maps to ``is_nan=True`` with no payload and no
+    signalling/quiet distinction. Sufficient for the synthetic-f64 generators,
+    which never construct payloaded NaNs, so this is not a true inverse of
+    ``fp_value_to_bits``.
+    """
     sign = (bits >> 63) & 1
     exp = (bits >> 52) & 0x7FF
     mant = bits & _F64_MANTISSA_MASK
@@ -437,7 +443,13 @@ def _gen_underflow_div(start_line: int) -> list['TestCase']:
 
 
 def _gen_hamming_add_sub(start_line: int) -> list['TestCase']:
-    """Adjacent values differing by 1 ULP: addition and subtraction (Hamming-distance edge cases)."""
+    """Adjacent values differing by 1 ULP: addition and subtraction (Hamming-distance edge cases).
+
+    Both operands of each test share a single sign bit so the 1-ULP adjacency
+    invariant (``base + diff == ulp`` and ``ulp - diff == base``) holds for
+    negative operands too: with a shared sign s, ``s·base + s·diff == s·ulp``.
+    Independent signs would break the relationship for the mixed-sign cases.
+    """
     tests = []
     line_num = start_line
     for i in range(30):
@@ -450,15 +462,17 @@ def _gen_hamming_add_sub(start_line: int) -> list['TestCase']:
         ulp = float64_from_bits(ulp_bits)
         diff = ulp - base
 
-        a_bits = float64_to_bits(base) | _random_sign_bit()
-        b_bits = float64_to_bits(diff) | _random_sign_bit()
+        sign_add = _random_sign_bit()
+        a_bits = float64_to_bits(base) | sign_add
+        b_bits = float64_to_bits(diff) | sign_add
         tests.append(_make_synthetic_f64_test(
             Operation.ADD, a_bits, b_bits, line_num, f"hamming_add_{i}"
         ))
         line_num += 1
 
-        a_bits_sub = float64_to_bits(ulp) | _random_sign_bit()
-        b_bits_sub = float64_to_bits(diff) | _random_sign_bit()
+        sign_sub = _random_sign_bit()
+        a_bits_sub = float64_to_bits(ulp) | sign_sub
+        b_bits_sub = float64_to_bits(diff) | sign_sub
         tests.append(_make_synthetic_f64_test(
             Operation.SUBTRACT, a_bits_sub, b_bits_sub, line_num, f"hamming_sub_{i}"
         ))

--- a/scripts/generate_tests.py
+++ b/scripts/generate_tests.py
@@ -909,22 +909,20 @@ def _source_to_module_name(source_file: str) -> str:
 
 
 def generate_ci_matrix(
-    tests_by_file: dict[str, list[TestCase]], 
+    tests_by_file: dict[str, list[TestCase]],
     output_path: str,
     chunk_size: int = 25,
     max_tests_per_package: int = 1250,
     force_f64: bool = False,
     generate_both: bool = False,
-    use_packages: bool = True
 ) -> list[dict]:
     """Generate a CI matrix JSON file for GitHub Actions.
-    
+
     Lists all packages that will be generated. Large test files are automatically
     split into multiple packages by generate_noir_packages.
-    
+
     Args:
         max_tests_per_package: Maximum tests per package (50 chunks * 25 tests = 1250)
-        use_packages: If True, generate matrix for separate packages (new style)
     """
     import json
     
@@ -1108,99 +1106,6 @@ ieee754 = {{ path = "../../ieee754" }}
     return results
 
 
-def generate_noir_file_per_source(
-    tests_by_file: dict[str, list[TestCase]], 
-    output_dir: str, 
-    add_debug: bool = False,
-    chunk_size: int = 25,
-    force_f64: bool = False,
-    generate_both: bool = False
-) -> dict[str, int]:
-    """Generate separate Noir test files for each source file, chunked into groups.
-    
-    Args:
-        tests_by_file: Dict mapping source filenames to test cases
-        output_dir: Output directory for generated files
-        add_debug: Add println statements for debugging
-        chunk_size: Number of tests per chunk file
-        force_f64: If True, convert f32 tests to f64 only
-        generate_both: If True, generate both f32 and f64 tests (overrides force_f64)
-    """
-    results = {}
-    module_names = []
-    
-    for source_file, tests in tests_by_file.items():
-        module_name = _source_to_module_name(source_file)
-        
-        # Generate all test code
-        if generate_both:
-            # Generate both f32 tests (index 0..n-1) and f64 tests (index n..2n-1)
-            # For native f64 tests (like synthetic tests), only generate once (in the f64 pass)
-            f32_tests = [
-                code for i, test in enumerate(tests)
-                if test.precision == Precision.BINARY32 and (code := generate_noir_test(test, i, add_debug, force_f64=False))
-            ]
-            # For native f64 tests, don't set force_f64 (they're already f64)
-            # For f32 tests, convert to f64
-            f64_tests = []
-            for i, test in enumerate(tests):
-                if test.precision == Precision.BINARY64:
-                    # Native f64 test - generate directly
-                    code = generate_noir_test(test, len(tests) + i, add_debug, force_f64=False)
-                else:
-                    # f32 test - convert to f64
-                    code = generate_noir_test(test, len(tests) + i, add_debug, force_f64=True)
-                if code:
-                    f64_tests.append(code)
-            all_test_code = f32_tests + f64_tests
-        else:
-            all_test_code = [
-                code for i, test in enumerate(tests)
-                if (code := generate_noir_test(test, i, add_debug, force_f64))
-            ]
-        
-        if not all_test_code:
-            continue
-        
-        # Create folder and write chunks
-        module_dir = os.path.join(output_dir, module_name)
-        os.makedirs(module_dir, exist_ok=True)
-        
-        chunks = [all_test_code[i:i + chunk_size] for i in range(0, len(all_test_code), chunk_size)]
-        chunk_names = []
-        
-        for chunk_idx, chunk in enumerate(chunks):
-            chunk_name = f"chunk_{chunk_idx:04d}"
-            chunk_names.append(chunk_name)
-            
-            # Analyze this chunk to determine required imports
-            analysis = analyze_test_code(chunk)
-            header = generate_noir_header_from_analysis(f"{source_file} (chunk {chunk_idx})", analysis)
-            
-            with open(os.path.join(module_dir, f"{chunk_name}.nr"), 'w') as f:
-                f.write(header)
-                f.write('\n'.join(chunk))
-        
-        # Generate mod.nr for this module
-        with open(os.path.join(module_dir, "mod.nr"), 'w') as f:
-            f.write(f"// Auto-generated module index for {source_file}\n")
-            f.write(f"// Contains {len(all_test_code)} tests in {len(chunks)} chunks of {chunk_size}\n\n")
-            f.writelines(f"mod {name};\n" for name in chunk_names)
-        
-        print(f"Generated {len(all_test_code)} tests in {len(chunks)} chunks to {module_dir}/")
-        results[source_file] = len(all_test_code)
-        module_names.append(module_name)
-    
-    # Generate top-level module index
-    with open(os.path.join(output_dir, "mod.nr"), 'w') as f:
-        f.write("// Auto-generated module index for IEEE 754 tests\n")
-        f.write("// Each module corresponds to a source .fptest file\n\n")
-        f.writelines(f"mod {name};\n" for name in sorted(module_names))
-    
-    print(f"\nGenerated module index at {output_dir}/mod.nr")
-    return results
-
-
 def get_cache_dir() -> Path:
     """Get the cache directory path, creating it if needed."""
     # Cache directory is relative to the project root (parent of scripts/)
@@ -1251,7 +1156,6 @@ Examples:
   %(prog)s --files Add-Shift.fptest     # Use specific file(s)
   %(prog)s --all                        # Use all available test files
   %(prog)s --all --packages             # Generate separate test packages (recommended)
-  %(prog)s --all --split                # Generate chunked test folders per source (old style)
   %(prog)s --all --packages --chunk-size 50  # Use 50 tests per chunk file
   %(prog)s --list                       # List available test files
   %(prog)s --local test.fptest          # Use a local file instead of downloading
@@ -1287,12 +1191,7 @@ Examples:
     parser.add_argument(
         '--output-dir',
         default=None,
-        help='Output directory for split test files (use with --split)'
-    )
-    parser.add_argument(
-        '--split',
-        action='store_true',
-        help='Generate separate test files for each source file (old style, as modules in src/)'
+        help='Output directory for generated test packages (use with --packages)'
     )
     parser.add_argument(
         '--packages',
@@ -1303,7 +1202,7 @@ Examples:
         '--chunk-size',
         type=int,
         default=25,
-        help='Number of tests per chunk file when using --split (default: 25)'
+        help='Number of tests per chunk file within a package (default: 25)'
     )
     parser.add_argument(
         '--max-tests-per-package',
@@ -1336,7 +1235,7 @@ Examples:
         '--max-tests',
         type=int,
         default=None,
-        help='Maximum number of tests to generate (per file when using --split)'
+        help='Maximum number of tests to generate (per source file)'
     )
     parser.add_argument(
         '--debug',
@@ -1351,7 +1250,7 @@ Examples:
     parser.add_argument(
         '--ci-matrix',
         metavar='PATH',
-        help='Generate CI matrix JSON file for GitHub Actions (use with --split)'
+        help='Generate CI matrix JSON file for GitHub Actions (use with --packages)'
     )
     
     args = parser.parse_args()
@@ -1485,51 +1384,14 @@ Examples:
         # Generate CI matrix if requested
         if args.ci_matrix:
             generate_ci_matrix(
-                tests_by_file, 
-                args.ci_matrix, 
-                chunk_size=args.chunk_size, 
+                tests_by_file,
+                args.ci_matrix,
+                chunk_size=args.chunk_size,
                 max_tests_per_package=args.max_tests_per_package,
-                force_f64=args.generate_f64, 
+                force_f64=args.generate_f64,
                 generate_both=args.generate_f64,
-                use_packages=True
             )
     
-    elif args.split:
-        # Generate separate files per source
-        output_dir = args.output_dir or "src/ieee754_tests"
-        os.makedirs(output_dir, exist_ok=True)
-        
-        tests_by_file = {}
-        total_parsed = 0
-        
-        for filepath in fptest_files:
-            source_name = os.path.basename(filepath)
-            print(f"Parsing {source_name}...")
-            tests = parse_fptest_file(filepath)
-            total_parsed += len(tests)
-            filtered = filter_tests(tests)
-            if filtered:
-                tests_by_file[source_name] = filtered
-                print(f"  {len(tests)} parsed, {len(filtered)} after filtering")
-        
-        print(f"\nParsed {total_parsed} total test cases")
-        
-        results = generate_noir_file_per_source(
-            tests_by_file, 
-            output_dir, 
-            add_debug=args.debug,
-            chunk_size=args.chunk_size,
-            force_f64=args.generate_f64,
-            generate_both=args.generate_f64  # When --generate-f64 is set, generate both
-        )
-        
-        total_generated = sum(results.values())
-        print(f"\nTotal: {total_generated} tests generated across {len(results)} files")
-        
-        # Generate CI matrix if requested
-        if args.ci_matrix:
-            generate_ci_matrix(tests_by_file, args.ci_matrix, chunk_size=args.chunk_size, force_f64=args.generate_f64, generate_both=args.generate_f64)
-        
     else:
         # Parse all test files into one list
         all_tests = []

--- a/scripts/generate_tests.py
+++ b/scripts/generate_tests.py
@@ -741,6 +741,33 @@ def _compute_expected_bits(test: 'TestCase', f1: float, f2: float, is_float32: b
     return float64_to_bits(result_float), False
 
 
+def _operand_bits_and_floats(test: 'TestCase', force_f64: bool) -> tuple[int, int, float, float]:
+    """Convert test operands to in-circuit bit representations and Python floats.
+
+    Handles the f32->f64 coercion case (force_f64 with float32 inputs).
+    Returns (bits_a, bits_b, float_a, float_b).
+    """
+    original_is_f32 = test.precision == Precision.BINARY32
+    is_float32 = original_is_f32 and not force_f64
+
+    if force_f64 and original_is_f32:
+        # Round through float32 first so the f64 circuit sees the same value
+        # the source f32 test case carried.
+        bits1_f32 = fp_value_to_bits32(test.operand1)
+        bits2_f32 = fp_value_to_bits32(test.operand2)
+        f1 = float32_from_bits(bits1_f32)
+        f2 = float32_from_bits(bits2_f32)
+        bits1 = float64_to_bits(f1)
+        bits2 = float64_to_bits(f2)
+        return bits1, bits2, f1, f2
+
+    to_bits = fp_value_to_bits32 if is_float32 else fp_value_to_bits64
+    from_bits = float32_from_bits if is_float32 else float64_from_bits
+    bits1 = to_bits(test.operand1)
+    bits2 = to_bits(test.operand2)
+    return bits1, bits2, from_bits(bits1), from_bits(bits2)
+
+
 def generate_noir_test(test: TestCase, index: int, add_debug: bool = False, force_f64: bool = False) -> Optional[str]:
     """Generate Noir test code for a single test case.
     
@@ -772,23 +799,7 @@ def generate_noir_test(test: TestCase, index: int, add_debug: bool = False, forc
     sign_bit = 0x80000000 if is_float32 else 0x8000000000000000
     hex_width = 8 if is_float32 else 16
     
-    # Convert operands to bits
-    # For force_f64 mode, first convert to f32, then to f64 value, then to f64 bits
-    if force_f64 and original_is_f32:
-        # Get the float32 values first
-        bits1_f32 = fp_value_to_bits32(test.operand1)
-        bits2_f32 = fp_value_to_bits32(test.operand2)
-        f1 = float32_from_bits(bits1_f32)
-        f2 = float32_from_bits(bits2_f32)
-        # Convert to f64 bits (Python floats are f64, so this is straightforward)
-        bits1 = float64_to_bits(f1)
-        bits2 = float64_to_bits(f2)
-    else:
-        to_bits = fp_value_to_bits32 if is_float32 else fp_value_to_bits64
-        from_bits = float32_from_bits if is_float32 else float64_from_bits
-        bits1 = to_bits(test.operand1)
-        bits2 = to_bits(test.operand2)
-        f1, f2 = from_bits(bits1), from_bits(bits2)
+    bits1, bits2, f1, f2 = _operand_bits_and_floats(test, force_f64)
     
     # Skip tests where an operand underflows to zero when it wasn't supposed to be zero
     # The test file may expect a finite result, but IEEE float32 will give infinity/NaN


### PR DESCRIPTION
## Summary

Multi-track parallel cleanup of `scripts/generate_tests.py` plus a small bug fix in `fp_value_to_bits`. The earlier AI-generated test-scaffolding pipeline was hard to read; this refactor preserves behaviour while making the structure tractable.

Five underlying commits, organised as four parallel tracks merged with `--no-ff` to preserve provenance:

| Track | Underlying commit(s) | Effect |
| --- | --- | --- |
| A | `bd4626b`, `09be5e1` | Extract `_compute_expected_bits` and `_operand_bits_and_floats` from `generate_noir_test`. Behaviour-identical, byte-identical generated output. |
| B | `32ec361` | Drop unused `--split` CLI mode (verified dead via grep across CI workflows / shell scripts / Python / Markdown). −138 LOC including stale `CONTRIBUTING.md` mentions. |
| C | `46687d2` | Decompose 275-line `generate_synthetic_f64_tests` god function into 12 focused generators, normalise asymmetric sign-randomisation across all loops (5 loops were silently flipping fewer signs than intended — confirmed oversight, not coverage shaping). |
| D | `73420df` | Remove dead `(frac_bits_24 & 0)` sticky-bit term in `fp_value_to_bits` 24→23 rounding. Provably no-op (38,760 generated tests byte-identical before/after). |

`fix(tests): use generate_noir_test_name in force_f64 branch` (`be87a0f`) and `refactor(tests): extract shared Noir-test-header renderer` (`73e5d9b`) landed on `main` before the parallel split — they're already on the base branch.

## Test plan

- [x] `nargo test --workspace` — 170/170 unit tests pass on merged main
- [x] `python -m py_compile scripts/generate_tests.py` and `scripts/run_tests.py` — clean
- [x] Full `python3 scripts/generate_tests.py --all --packages --synthetic-f64 --generate-f64 --output-dir test_packages --ci-matrix .github/test-matrix.json` — 73 packages / 77,850 tests; **`.github/test-matrix.json` regenerates byte-identical to the committed version**
- [x] `python3 scripts/run_tests.py --package ieee754_test_synthetic_f64_corner_cases` — 330/330 pass (the only package whose generated content differs from baseline, due to Track C's normalised sign-randomisation)
- [x] Roborev review per underlying commit — all 5 commits + the 2 pre-track commits returned **"No issues found"** under codex+gpt-5.5 (and copilot+gpt-5.5 for tracks B and D as a second opinion)
- [ ] Repository-required `test-summary` status check — awaiting CI

## Notes

- No library code changed (everything in `ieee754/` is untouched).
- Sign-randomisation normalisation in Track C perturbs the contents of generated test chunks for the synthetic-f64 corner-cases package only; the deterministic seed (42) reshuffles those 330 tests but they all still pass.
- `OPTIMIZATION.md` and the `copilot/optimize-operators-reduce-noir-gates` branch are unaffected by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)