### PR TITLE
feat(circuits): count_leading_zeros_u64 via unconstrained + verified pattern

### DIFF
--- a/ieee754/src/lib.nr
+++ b/ieee754/src/lib.nr
@@ -5,7 +5,9 @@ pub mod float64;
 pub mod float;
 pub mod unconstrained_ops;
 
-pub use crate::unconstrained_ops::{count_leading_zeros_u23_verified, count_leading_zeros_u64_verified};
+pub use crate::unconstrained_ops::{
+    count_leading_zeros_u23_verified, count_leading_zeros_u64_verified,
+};
 
 // Re-export public API
 pub use crate::float::{

--- a/ieee754/src/lib.nr
+++ b/ieee754/src/lib.nr
@@ -5,7 +5,7 @@ pub mod float64;
 pub mod float;
 pub mod unconstrained_ops;
 
-pub use crate::unconstrained_ops::count_leading_zeros_u23_verified;
+pub use crate::unconstrained_ops::{count_leading_zeros_u23_verified, count_leading_zeros_u64_verified};
 
 // Re-export public API
 pub use crate::float::{

--- a/ieee754/src/unconstrained_ops.nr
+++ b/ieee754/src/unconstrained_ops.nr
@@ -330,3 +330,323 @@ fn test_clz_u23_hint_bit_above_fails() {
     let count: u32 = 17_u32;
     let _ = verify_clz_u23_relation(value, count);
 }
+
+// ============================================================================
+// count_leading_zeros_u64
+// ============================================================================
+
+/// Brillig hint: count the number of leading zeros in `value`, treating it
+/// as a 64-bit-wide register.
+///
+/// Returns `count: u64` such that:
+///
+/// - if `value == 0`: `count == 64`;
+/// - otherwise: `count` is the number of zero bits between bit 63 (the top
+///   of the register) and the most significant set bit, exclusive of the
+///   set bit itself. Equivalently `count == 63 - msb_position`, where
+///   `msb_position` is the index of the highest set bit of `value`.
+///
+/// This matches the IEEE 754 double-precision normalisation use case where
+/// a 64-bit accumulator must be left-shifted until its top bit lines up with
+/// the implicit leading bit of the result.
+///
+/// This function is `unconstrained` and contributes no ACIR gates. Its output
+/// MUST be validated by `count_leading_zeros_u64_verified` before being
+/// trusted.
+///
+/// Crate-private deliberately: a downstream caller must not be able to bypass
+/// the verifier by importing the raw hint. The only sanctioned consumer is
+/// `count_leading_zeros_u64_verified` immediately below.
+unconstrained fn count_leading_zeros_u64_unconstrained(value: u64) -> u64 {
+    if value == 0_u64 {
+        // No bits set => 64 leading zeros by convention.
+        64_u64
+    } else {
+        // Walk from the top of the register downward, returning as soon as
+        // we hit the first set bit. Unconstrained code is free to use early
+        // exits so the procedural shape mirrors a software CLZ.
+        let mut count: u64 = 0_u64;
+        for i in 0..64 {
+            let probe_pos: u64 = 63_u64 - (i as u64);
+            let probe_bit: u64 = (value >> probe_pos) & 1_u64;
+            if probe_bit == 1_u64 {
+                count = i as u64;
+                break;
+            }
+        }
+        count
+    }
+}
+
+/// Constrained verifier: returns `count`, asserting the relation that pins it
+/// uniquely to the leading-zero count of `value` interpreted as a 64-bit
+/// register.
+///
+/// # Public-input contract
+/// - Input: `value: u64`. All 64 bits are inspected.
+/// - Output: `count: u64` in the range `0..=64`.
+///
+/// # SAFETY PROOF (sketch -- not mechanised)
+///
+/// The verifier asserts the relation `R(value, count)`:
+///
+/// 1. `count <= 64`.
+/// 2. **Zero case**: if `count == 64` then `value == 0`.
+/// 3. **Non-zero case**: if `count <= 63` then there exists `top_bit_pos`
+///    with `top_bit_pos == 63 - count` and:
+///      a. bit `top_bit_pos` of `value` is set, i.e.
+///         `(value >> top_bit_pos) & 1 == 1`; and
+///      b. no bits of `value` above `top_bit_pos` are set, i.e.
+///         `value >> (top_bit_pos + 1) == 0`, equivalently
+///         `value < 2^(top_bit_pos + 1) = 2^(64 - count)`.
+///
+/// The boundary `count == 0` is handled inline: clause (3b) becomes a shift
+/// by 64, which we replace with the trivially-true bound (no bits exist
+/// above bit 63 in a 64-bit word). Concretely we branch on `count == 0` and
+/// only check (3a) in that subcase.
+///
+/// **Uniqueness** (no second `count'` satisfies `R(value, count')`):
+///
+/// - If `value == 0` then clause (3a) cannot hold for any `count <= 63`
+///   (no bit is set), so only `count == 64` (clause 2) satisfies `R`.
+/// - If `value != 0` then `count == 64` is excluded by clause (2). Among
+///   the remaining `count <= 63`, clause (3b) bounds `value` strictly below
+///   `2^(64 - count)`; equivalently, the most significant set bit has
+///   index strictly less than `64 - count`, i.e. at most `63 - count`.
+///   Clause (3a) forces equality at exactly bit `63 - count`. The most
+///   significant set bit of a fixed non-zero `value` is unique (standard
+///   binary-representation theorem), so `count` is uniquely determined.
+///
+/// Therefore exactly one `count` satisfies `R` for any input `value`.
+///
+/// **Correctness** (the unique `count` matches the spec): by definition of
+/// `count_leading_zeros` on a 64-bit register, the spec is `64` for the
+/// zero case and `63 - msb_position(value)` otherwise. Clauses (2) and (3)
+/// implement exactly this definition, matching the Lean spec
+/// `Spec.cluz_u64` in
+/// `proofs/Ieee754/.../UnconstrainedOps.lean`.
+///
+/// This sketch is a reading aid; the soundness has not been mechanised
+/// (the `clz_u64_unique` and `clz_u64_correct` Lean obligations remain
+/// `sorry`-stubbed).
+pub fn count_leading_zeros_u64_verified(value: u64) -> u64 {
+    // Safety: `verify_clz_u64_relation` enforces the relation that uniquely
+    // pins `count` to the leading-zero count of `value`; see the SAFETY
+    // PROOF block above.
+    let count: u64 = unsafe { count_leading_zeros_u64_unconstrained(value) };
+    verify_clz_u64_relation(value, count)
+}
+
+/// Constrained relation check shared by `count_leading_zeros_u64_verified`
+/// and the adversarial tests. Asserts clauses (1), (2), (3a), (3b) of the
+/// SAFETY PROOF and returns `count` unchanged on success.
+///
+/// Private to this module so the assertion error strings remain
+/// implementation details. Sharing the helper between production and tests
+/// means an adversarial-test failure also flags a regression in the
+/// production verifier path.
+fn verify_clz_u64_relation(value: u64, count: u64) -> u64 {
+    // Clause (1): count <= 64.
+    assert(count <= 64_u64, "count_leading_zeros_u64: count above 64");
+
+    if count == 64_u64 {
+        // Clause (2): zero case.
+        assert(value == 0_u64, "count_leading_zeros_u64: count==64 but value nonzero");
+    } else {
+        // Clause (3): non-zero case. We have count <= 63 here.
+        //
+        // top_bit_pos in 0..=63.
+        let top_bit_pos: u64 = 63_u64 - count;
+
+        // Clause (3a): bit `top_bit_pos` of value is set.
+        // `(value >> top_bit_pos) & 1 == 1`. Both sides are u64.
+        let probe: u64 = (value >> top_bit_pos) & 1_u64;
+        assert(probe == 1_u64, "count_leading_zeros_u64: leading bit not set");
+
+        // Clause (3b): no bits of value are set above `top_bit_pos`.
+        //
+        // Expressed as a single right-shift comparison: shifting value
+        // right by `top_bit_pos + 1` must yield zero. The boundary
+        // `count == 0` would make this a shift by 64, which is
+        // outside the well-defined range for u64 right shifts in Noir;
+        // in that subcase there are no bits above bit 63 by definition,
+        // so clause (3b) holds trivially and we skip the shift.
+        if count != 0_u64 {
+            let above_shift: u64 = top_bit_pos + 1_u64;
+            let above: u64 = value >> above_shift;
+            assert(above == 0_u64, "count_leading_zeros_u64: bit set above leading position");
+        }
+    }
+
+    count
+}
+
+// ============================================================================
+// Tests -- happy paths (u64)
+// ============================================================================
+
+#[test]
+fn test_clz_u64_all_zero() {
+    let count: u64 = count_leading_zeros_u64_verified(0_u64);
+    assert(count == 64_u64);
+}
+
+#[test]
+fn test_clz_u64_lsb_only() {
+    // Only bit 0 set: 63 leading zeros.
+    let count: u64 = count_leading_zeros_u64_verified(1_u64);
+    assert(count == 63_u64);
+}
+
+#[test]
+fn test_clz_u64_msb_only() {
+    // Only bit 63 set: 0 leading zeros.
+    let value: u64 = 1_u64 << 63_u64;
+    let count: u64 = count_leading_zeros_u64_verified(value);
+    assert(count == 0_u64);
+}
+
+#[test]
+fn test_clz_u64_full_value() {
+    // All 64 bits set: 0 leading zeros (bit 63 is set).
+    let count: u64 = count_leading_zeros_u64_verified(0xFFFF_FFFF_FFFF_FFFF_u64);
+    assert(count == 0_u64);
+}
+
+#[test]
+fn test_clz_u64_bit_32() {
+    // Only bit 32 set: leading zeros = 63 - 32 = 31.
+    let value: u64 = 1_u64 << 32_u64;
+    let count: u64 = count_leading_zeros_u64_verified(value);
+    assert(count == 31_u64);
+}
+
+#[test]
+fn test_clz_u64_bit_31() {
+    // Only bit 31 set: leading zeros = 63 - 31 = 32.
+    let value: u64 = 1_u64 << 31_u64;
+    let count: u64 = count_leading_zeros_u64_verified(value);
+    assert(count == 32_u64);
+}
+
+#[test]
+fn test_clz_u64_bit_52() {
+    // Bit 52 = position of float64 implicit leading bit; the dominant call
+    // site for this primitive in normalisation paths.
+    let value: u64 = 1_u64 << 52_u64;
+    let count: u64 = count_leading_zeros_u64_verified(value);
+    assert(count == 11_u64);
+}
+
+#[test]
+fn test_clz_u64_bit_pattern() {
+    // Bits 5, 17 and 40 set => msb position = 40 => count = 63 - 40 = 23.
+    let value: u64 = (1_u64 << 40_u64) | (1_u64 << 17_u64) | (1_u64 << 5_u64);
+    let count: u64 = count_leading_zeros_u64_verified(value);
+    assert(count == 23_u64);
+}
+
+#[test]
+fn test_clz_u64_bit_62() {
+    // Only bit 62 set: count = 63 - 62 = 1.
+    let value: u64 = 1_u64 << 62_u64;
+    let count: u64 = count_leading_zeros_u64_verified(value);
+    assert(count == 1_u64);
+}
+
+#[test]
+fn test_clz_u64_low_half_only() {
+    // Pattern entirely in the low half: bits 0..32 set => msb is bit 31.
+    let value: u64 = 0x0000_0000_FFFF_FFFF_u64;
+    let count: u64 = count_leading_zeros_u64_verified(value);
+    assert(count == 32_u64);
+}
+
+// ============================================================================
+// Tests -- adversarial: each isolates one verifier clause (u64)
+// ============================================================================
+//
+// Each `hint_clz_u64_*` generator produces a deliberately corrupt
+// unconstrained witness for a single tampering mode; the matching test
+// feeds it through `verify_clz_u64_relation` and asserts that the
+// expected error string fires. Sharing `verify_clz_u64_relation` between
+// production and tests means a regression in the production verifier
+// path would be caught here too (mirrors the clz_u23 round-1 fix).
+
+/// Always-64 hint: claims `count = 64` regardless of input.
+unconstrained fn hint_clz_u64_always_64(_value: u64) -> u64 {
+    64_u64
+}
+
+/// Out-of-range hint: returns 65 (above the 64 ceiling).
+unconstrained fn hint_clz_u64_out_of_range(_value: u64) -> u64 {
+    65_u64
+}
+
+/// Off-by-one-too-small hint: for `value == 1` the correct count is 63;
+/// returning 62 fails clause (3a) -- bit `(63 - 62) = 1` is not set in
+/// `0x1`.
+unconstrained fn hint_clz_u64_too_small(_value: u64) -> u64 {
+    62_u64
+}
+
+/// Off-by-one-too-large hint: for `value == 1` the correct count is 63;
+/// returning 64 falsely claims the all-zero case and triggers clause (2).
+unconstrained fn hint_clz_u64_falsely_zero(_value: u64) -> u64 {
+    64_u64
+}
+
+#[test]
+fn test_clz_u64_hint_always_64_passes_for_zero() {
+    // The always-64 hint *happens* to be correct when value == 0, so the
+    // verifier should accept it. Sanity check that the harness works.
+    // Safety: adversarial test path; we accept this only because
+    // `value == 0` is the canonical zero case and the verifier confirms it.
+    let count: u64 = unsafe { hint_clz_u64_always_64(0_u64) };
+    let returned: u64 = verify_clz_u64_relation(0_u64, count);
+    assert(returned == 64_u64);
+}
+
+#[test(should_fail_with = "count above 64")]
+fn test_clz_u64_hint_out_of_range_fails() {
+    // Clause (1): count must be <= 64.
+    // Safety: adversarial path; the verifier is expected to reject.
+    let count: u64 = unsafe { hint_clz_u64_out_of_range(0_u64) };
+    let _ = verify_clz_u64_relation(0_u64, count);
+}
+
+#[test(should_fail_with = "count==64 but value nonzero")]
+fn test_clz_u64_hint_falsely_zero_fails() {
+    // Clause (2): if count == 64 then value must be zero. Feeding a
+    // non-zero input with count == 64 should trip this clause.
+    // Safety: adversarial path.
+    let count: u64 = unsafe { hint_clz_u64_falsely_zero(1_u64) };
+    let _ = verify_clz_u64_relation(1_u64, count);
+}
+
+#[test(should_fail_with = "leading bit not set")]
+fn test_clz_u64_hint_too_small_fails() {
+    // For value == 1 the correct count is 63; hint_clz_u64_too_small
+    // returns 62. Then top_bit_pos = 63 - 62 = 1, but bit 1 of 0x1 is 0,
+    // so clause (3a) fires.
+    // Safety: adversarial path.
+    let count: u64 = unsafe { hint_clz_u64_too_small(1_u64) };
+    let _ = verify_clz_u64_relation(1_u64, count);
+}
+
+#[test(should_fail_with = "bit set above leading position")]
+fn test_clz_u64_hint_bit_above_fails() {
+    // Manually craft a (value, count) pair that satisfies clauses (1),
+    // (2), and (3a) but violates clause (3b): a bit set above the
+    // leading position.
+    //
+    // Take value with bits 5 and 40 set. The true count is 63 - 40 = 23.
+    // Feeding the verifier `count = 58` would put `top_bit_pos = 5`:
+    //   - clause (3a) holds: bit 5 is set;
+    //   - clause (3b) requires value < 2^(64 - 58) = 2^6 = 64, but
+    //     value = (1 << 40) | (1 << 5) >= 2^40, so (3b) fires.
+    // Safety: adversarial path; the wrong-count witness is intentional.
+    let value: u64 = (1_u64 << 40_u64) | (1_u64 << 5_u64);
+    let count: u64 = 58_u64;
+    let _ = verify_clz_u64_relation(value, count);
+}

--- a/scripts/benchmark_gates.py
+++ b/scripts/benchmark_gates.py
@@ -100,6 +100,189 @@ BENCHMARKS = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Primitive (isolated and composed) benchmarks for the unconstrained-with-
+# verifier pattern. These let us measure individual helpers from
+# `ieee754::unconstrained_ops` against the in-tree binary-search baseline
+# they aim to replace, without yet swapping any call sites.
+#
+# Each entry has the same shape as `BENCHMARKS` plus optional `extra_use`
+# and `prelude` keys for extra imports and helper functions injected
+# above `main`. Measurements are written into a separate
+# `primitive_benchmarks` block in the JSON output so they don't pollute
+# the headline `benchmarks` table.
+# ---------------------------------------------------------------------------
+
+PRIMITIVE_BENCHMARKS = {
+    # -- Isolated: the verifier on its own vs. an inlined binary-search
+    #    baseline. This matches the "clean room" comparison reported for
+    #    `clz_u23` in PR #36; if anything, this number is friendlier to
+    #    the baseline because the constant inputs of a one-shot caller
+    #    can fold large parts of the binary search away.
+    "clz_u64_isolated_verified": {
+        "extra_use": "use ieee754::count_leading_zeros_u64_verified;",
+        "prelude": "",
+        "inputs": "value: pub u64",
+        "body": """
+    count_leading_zeros_u64_verified(value)
+""",
+        "return_type": "pub u64",
+    },
+    "clz_u64_isolated_binsearch_baseline": {
+        "extra_use": "",
+        "prelude": """
+fn clz_u64_binsearch(value: u64) -> u64 {
+    let mut leading_zeros: u64 = 0;
+    let mut v = value;
+    if v & 0xFFFFFFFF00000000 == 0 {
+        leading_zeros += 32;
+        v <<= 32;
+    }
+    if v & 0xFFFF000000000000 == 0 {
+        leading_zeros += 16;
+        v <<= 16;
+    }
+    if v & 0xFF00000000000000 == 0 {
+        leading_zeros += 8;
+        v <<= 8;
+    }
+    if v & 0xF000000000000000 == 0 {
+        leading_zeros += 4;
+        v <<= 4;
+    }
+    if v & 0xC000000000000000 == 0 {
+        leading_zeros += 2;
+        v <<= 2;
+    }
+    if v & 0x8000000000000000 == 0 {
+        leading_zeros += 1;
+    }
+    leading_zeros
+}
+""",
+        "inputs": "value: pub u64",
+        "body": """
+    clz_u64_binsearch(value)
+""",
+        "return_type": "pub u64",
+    },
+    # -- Composed: emulate the leading-zero subnormal-normalisation step
+    #    that `add_float64` performs (binary-search CLZ followed by a
+    #    bounded left shift driven by the count). The baseline copies the
+    #    in-tree code verbatim from `ieee754/src/float64/add.nr`; the
+    #    candidate replaces the binary search with the verified primitive.
+    #    This is the measurement that actually answers
+    #    "should we swap call sites?".
+    "clz_u64_composed_verified": {
+        "extra_use": "use ieee754::count_leading_zeros_u64_verified;",
+        "prelude": """
+fn normalise_with_verified(result_mant: u64, result_exp: u64) -> (u64, u64) {
+    let target_bit: u64 = 60;
+    let leading_zeros: u64 = count_leading_zeros_u64_verified(result_mant);
+    let shift_needed = leading_zeros - (64 - target_bit - 1);
+    let max_shift = if result_exp > 1 { result_exp - 1 } else { 0 };
+    let actual_shift = if shift_needed <= max_shift {
+        shift_needed
+    } else {
+        max_shift
+    };
+    let new_mant = result_mant << actual_shift;
+    let new_exp = result_exp - actual_shift;
+    (new_mant, new_exp)
+}
+""",
+        "inputs": "result_mant: pub u64, result_exp: pub u64",
+        "body": """
+    let (m, e) = normalise_with_verified(result_mant, result_exp);
+    m + e
+""",
+        "return_type": "pub u64",
+    },
+    "clz_u64_composed_binsearch_baseline": {
+        "extra_use": "",
+        "prelude": """
+fn normalise_with_binsearch(result_mant: u64, result_exp: u64) -> (u64, u64) {
+    let target_bit: u64 = 60;
+    let mut leading_zeros: u64 = 0;
+    let mut v = result_mant;
+    if v & 0xFFFFFFFF00000000 == 0 {
+        leading_zeros += 32;
+        v <<= 32;
+    }
+    if v & 0xFFFF000000000000 == 0 {
+        leading_zeros += 16;
+        v <<= 16;
+    }
+    if v & 0xFF00000000000000 == 0 {
+        leading_zeros += 8;
+        v <<= 8;
+    }
+    if v & 0xF000000000000000 == 0 {
+        leading_zeros += 4;
+        v <<= 4;
+    }
+    if v & 0xC000000000000000 == 0 {
+        leading_zeros += 2;
+        v <<= 2;
+    }
+    if v & 0x8000000000000000 == 0 {
+        leading_zeros += 1;
+    }
+    let shift_needed = leading_zeros - (64 - target_bit - 1);
+    let max_shift = if result_exp > 1 { result_exp - 1 } else { 0 };
+    let actual_shift = if shift_needed <= max_shift {
+        shift_needed
+    } else {
+        max_shift
+    };
+    let new_mant = result_mant << actual_shift;
+    let new_exp = result_exp - actual_shift;
+    (new_mant, new_exp)
+}
+""",
+        "inputs": "result_mant: pub u64, result_exp: pub u64",
+        "body": """
+    let (m, e) = normalise_with_binsearch(result_mant, result_exp);
+    m + e
+""",
+        "return_type": "pub u64",
+    },
+}
+
+
+def create_primitive_benchmark_project(tmpdir: Path, name: str, benchmark: dict) -> Path:
+    """Create a temporary Noir project for a primitive (isolated or composed)
+    benchmark. Differs from `create_benchmark_project` only in that the
+    `main` body may pull in additional `use` lines and helper functions
+    via the `extra_use` and `prelude` keys.
+    """
+    project_dir = tmpdir / name
+    project_dir.mkdir(parents=True)
+    src_dir = project_dir / "src"
+    src_dir.mkdir()
+
+    nargo_toml = f"""[package]
+name = "{name}"
+type = "bin"
+authors = ["benchmark"]
+
+[dependencies]
+ieee754 = {{ path = "{get_project_root() / 'ieee754'}" }}
+"""
+    (project_dir / "Nargo.toml").write_text(nargo_toml)
+
+    extra_use = benchmark.get("extra_use", "")
+    prelude = benchmark.get("prelude", "")
+
+    main_nr = f"""{extra_use}
+{prelude}
+fn main({benchmark['inputs']}) -> {benchmark['return_type']} {{{benchmark['body']}}}
+"""
+    (src_dir / "main.nr").write_text(main_nr)
+
+    return project_dir
+
+
 def get_project_root():
     """Get the project root directory."""
     script_dir = Path(__file__).parent
@@ -167,6 +350,16 @@ def run_nargo_info(project_dir: Path) -> dict:
             if len(parts) >= 4:
                 # parts: [Package, Function, Expression Width, ACIR Opcodes, Brillig Opcodes]
                 try:
+                    width_str = parts[2].strip()
+                    if width_str != 'N/A':
+                        # Width comes through as e.g. "Bounded { width: 4 }"
+                        # or just an integer. Extract the trailing integer.
+                        m = re.search(r'(\d+)', width_str)
+                        if m:
+                            info["expression_width"] = int(m.group(1))
+                except (ValueError, IndexError):
+                    pass
+                try:
                     acir_str = parts[3].strip()
                     if acir_str != 'N/A':
                         info["acir_opcodes"] = int(acir_str)
@@ -200,13 +393,20 @@ def run_nargo_compile_and_info(project_dir: Path) -> dict:
     return run_nargo_info(project_dir)
 
 
-def benchmark_all(output_file: Path = None):
-    """Run all benchmarks and collect gate counts."""
+def benchmark_all(output_file: Path = None, primitives: bool = True):
+    """Run all benchmarks and collect gate counts.
+
+    Also runs the `PRIMITIVE_BENCHMARKS` (verifier vs. binary-search baseline,
+    isolated and composed) and writes them under the `primitive_benchmarks`
+    key when `primitives` is true.
+    """
     results = {
         "timestamp": datetime.now().isoformat(),
         "git_commit": get_git_commit(),
         "benchmarks": {},
     }
+    if primitives:
+        results["primitive_benchmarks"] = {}
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
@@ -218,7 +418,7 @@ def benchmark_all(output_file: Path = None):
                 project_dir = create_benchmark_project(tmpdir, name, benchmark)
                 info = run_nargo_compile_and_info(project_dir)
                 results["benchmarks"][name] = info
-                
+
                 # Print summary
                 if "error" in info:
                     print(f"ERROR: {info['error'][:50]}...")
@@ -233,6 +433,32 @@ def benchmark_all(output_file: Path = None):
             except Exception as e:
                 print(f"ERROR: {e}")
                 results["benchmarks"][name] = {"error": str(e)}
+
+        if primitives:
+            print()
+            for name, benchmark in PRIMITIVE_BENCHMARKS.items():
+                print(f"Benchmarking primitive {name}...", end=" ", flush=True)
+                try:
+                    project_dir = create_primitive_benchmark_project(
+                        tmpdir, name, benchmark
+                    )
+                    info = run_nargo_compile_and_info(project_dir)
+                    results["primitive_benchmarks"][name] = info
+
+                    if "error" in info:
+                        print(f"ERROR: {info['error'][:50]}...")
+                    elif "acir_opcodes" in info:
+                        print(f"ACIR: {info['acir_opcodes']}", end="")
+                        if "expression_width" in info:
+                            print(f", Width: {info['expression_width']}", end="")
+                        if "brillig_opcodes" in info:
+                            print(f", Brillig: {info['brillig_opcodes']}", end="")
+                        print()
+                    else:
+                        print(f"OK (parsing failed - check raw output)")
+                except Exception as e:
+                    print(f"ERROR: {e}")
+                    results["primitive_benchmarks"][name] = {"error": str(e)}
 
     # Save results
     if output_file is None:

--- a/scripts/benchmark_gates.py
+++ b/scripts/benchmark_gates.py
@@ -132,32 +132,43 @@ PRIMITIVE_BENCHMARKS = {
         "extra_use": "",
         "prelude": """
 fn clz_u64_binsearch(value: u64) -> u64 {
-    let mut leading_zeros: u64 = 0;
-    let mut v = value;
-    if v & 0xFFFFFFFF00000000 == 0 {
-        leading_zeros += 32;
-        v <<= 32;
+    // The 6-step binary-search count-leading-zeros baseline returns 63
+    // for `value == 0` (only the last conditional fires). To make this
+    // an apples-to-apples comparison against
+    // `count_leading_zeros_u64_verified` -- which specifies 64 for the
+    // zero case -- we add an explicit zero short-circuit. Without this
+    // the two circuits agree on every nonzero input but diverge at
+    // zero, which would invalidate the benchmark.
+    if value == 0 {
+        64
+    } else {
+        let mut leading_zeros: u64 = 0;
+        let mut v = value;
+        if v & 0xFFFFFFFF00000000 == 0 {
+            leading_zeros += 32;
+            v <<= 32;
+        }
+        if v & 0xFFFF000000000000 == 0 {
+            leading_zeros += 16;
+            v <<= 16;
+        }
+        if v & 0xFF00000000000000 == 0 {
+            leading_zeros += 8;
+            v <<= 8;
+        }
+        if v & 0xF000000000000000 == 0 {
+            leading_zeros += 4;
+            v <<= 4;
+        }
+        if v & 0xC000000000000000 == 0 {
+            leading_zeros += 2;
+            v <<= 2;
+        }
+        if v & 0x8000000000000000 == 0 {
+            leading_zeros += 1;
+        }
+        leading_zeros
     }
-    if v & 0xFFFF000000000000 == 0 {
-        leading_zeros += 16;
-        v <<= 16;
-    }
-    if v & 0xFF00000000000000 == 0 {
-        leading_zeros += 8;
-        v <<= 8;
-    }
-    if v & 0xF000000000000000 == 0 {
-        leading_zeros += 4;
-        v <<= 4;
-    }
-    if v & 0xC000000000000000 == 0 {
-        leading_zeros += 2;
-        v <<= 2;
-    }
-    if v & 0x8000000000000000 == 0 {
-        leading_zeros += 1;
-    }
-    leading_zeros
 }
 """,
         "inputs": "value: pub u64",


### PR DESCRIPTION
## Summary

Round 2 of the IEEE 754 unconstrained-with-verifier rebuild. Adds
`count_leading_zeros_u64_verified` to `ieee754::unconstrained_ops`,
mirroring the round 1 `count_leading_zeros_u23_verified` shape:

- `unconstrained fn count_leading_zeros_u64_unconstrained` -- crate-private Brillig hint.
- `pub fn count_leading_zeros_u64_verified` -- constrained verifier delegating to a private `verify_clz_u64_relation`.
- SAFETY PROOF doc-block stating uniqueness + correctness; the boundary `count == 0` is special-cased to avoid a u64 right-shift by 64.
- Re-exported from `ieee754::` via `lib.nr`.

Names line up with the `clz_u64_unique` / `clz_u64_correct` Lean
obligations in `proofs/Ieee754/.../UnconstrainedOps.lean` so the future
Lampe extraction will plug straight in. All bit widths are explicitly
annotated for `nargo 1.0.0-beta.17`.

## Tests

- 10 happy paths (zero, LSB, MSB, full, bits 31/32/52/62, mixed pattern, low-half-only).
- 5 adversarial cases sharing `verify_clz_u64_relation` with the production path -- one `should_fail_with` per assertion clause plus a sanity-passes case.

Total: 29 tests in `ieee754` (12 u23 + 15 u64 + the existing 2 sanity), all green; 170 in `ieee754_unit_tests`, all green.

## Gate impact

Extends `scripts/benchmark_gates.py` with a `PRIMITIVE_BENCHMARKS` dict
and adds Expression Width parsing to `nargo info`. Two pairs:

| Benchmark                                | Width | ACIR |
|------------------------------------------|------:|-----:|
| `clz_u64_isolated_binsearch_baseline`    |    96 |   17 |
| `clz_u64_isolated_verified`              |   112 |  100 |
| `clz_u64_composed_binsearch_baseline`    |   133 |   34 |
| `clz_u64_composed_verified`              |   164 |  100 |

Both Width and ACIR regress in both the isolated and composed regimes.
The previous round's hypothesis (that composing inside `add_float64`'s
normalisation step would unmask a win) is **refuted**: the verifier's
dynamic right-shift `value >> top_bit_pos` (where `top_bit_pos` is a
witness) costs more than the binary-search's six static
shifts/masks, even when the latter is followed by data-dependent
work.

## Verdict

No-go for call-site swap. The primitive lands in the public API as a
stable Lampe extraction target and for composition with later helpers
in the series, exactly as `clz_u23` did in PR #36.

## Roborev

Per-commit reviews (codex, gpt-5.5):

- d37aa99 -- No issues found.
- b5dfae9 -- Medium: isolated baseline returned 63 for zero; addressed in 6548040.
- 6548040 -- No issues found.

## Deferred

`count_leading_zeros_u52_verified` and `shift_right_sticky_u64_verified`
are not in this round; `clz_u52_unique`, `clz_u52_correct`,
`shr_sticky_u64_unique`, `shr_sticky_u64_correct` remain `sorry`-stubbed.

## Test plan

- [x] `nargo check --workspace` clean (only the pre-existing unused-import warning).
- [x] `nargo test --workspace` -- 199 tests pass.
- [x] Isolated + composed gate measurements collected on this branch.