### PR TITLE
ci: sync from workspace templates (phase 2)

### DIFF
--- a/.github/workflows/check-noir-version.yml
+++ b/.github/workflows/check-noir-version.yml
@@ -68,25 +68,43 @@ jobs:
           echo "Updated noir-versions.json:"
           cat .github/noir-versions.json
 
+      - name: Render PR body
+        if: steps.update.outputs.updated == 'true'
+        run: |
+          # Build the PR body in a shell step so we can interpolate the
+          # updated noir-versions.json. The peter-evans/create-pull-request
+          # `body:` input is treated as a literal string by the action — it
+          # does not run `$(...)` command substitution — so we generate the
+          # rendered body here and pass it via `body-path:` below.
+          {
+            echo "A new version of Noir has been released: **${{ steps.update.outputs.new_version }}**"
+            echo
+            echo "This PR updates the CI test matrix to include the new version while keeping the 3 most recent versions."
+            echo
+            echo "Updated versions:"
+            echo '```json'
+            cat .github/noir-versions.json
+            echo '```'
+            echo
+            echo "---"
+            echo "*This PR was automatically created by the version check workflow.*"
+          } > /tmp/pr-body.md
+
       - name: Create Pull Request
         if: steps.update.outputs.updated == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a dedicated PAT (`GH_TOKEN`) rather than the default
+          # `GITHUB_TOKEN`. Pushes / PRs created with `GITHUB_TOKEN` do not
+          # trigger downstream `on: push` / `on: pull_request` workflows
+          # (GitHub blocks this to avoid recursive workflow loops), so the
+          # automated Noir-version-matrix bump PRs would otherwise be left
+          # unvalidated by CI. `GH_TOKEN` is the same secret used in
+          # `automerge.yml`.
+          token: ${{ secrets.GH_TOKEN }}
           commit-message: "ci: add Noir ${{ steps.update.outputs.new_version }} to test matrix"
           title: "ci: add Noir ${{ steps.update.outputs.new_version }} to test matrix"
-          body: |
-            A new version of Noir has been released: **${{ steps.update.outputs.new_version }}**
-            
-            This PR updates the CI test matrix to include the new version while keeping the 3 most recent versions.
-            
-            Updated versions:
-            ```json
-            $(cat .github/noir-versions.json)
-            ```
-            
-            ---
-            *This PR was automatically created by the version check workflow.*
+          body-path: /tmp/pr-body.md
           branch: ci/noir-${{ steps.update.outputs.new_version }}
           delete-branch: true
           labels: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,16 @@
+# Canonical CI workflow template for Noir-flavoured sub-repos.
+#
+# Source of truth: zkp-sparql-workspace/templates/sub-repo/noir/.github/workflows/ci.yml.tmpl
+# Rendered by:    zkp-sparql-workspace/scripts/sync-standards.sh
+#
+# Hook blocks delimited by `# HOOK:<name>` / `# /HOOK:<name>` are kept when
+# `<name>` appears in this sub-repo's `ci_hooks` list in `.sync.json`, and
+# stripped otherwise. Variables `${PACKAGE_NAME}` etc. are NOT yet supported —
+# this template is lifted verbatim from `noir_IEEE754` (canonical per §3 of
+# `docs/cross-repo-consistency-plan.md`), so package names currently read
+# `ieee754`. Phase 2 of the migration plan introduces per-repo variable
+# substitution; until then, only `noir_IEEE754` should be rendered from this
+# template.
 name: CI
 
 on:

--- a/.github/workflows/gate-count-main.yml
+++ b/.github/workflows/gate-count-main.yml
@@ -1,8 +1,8 @@
 name: Update Gate Counts on Main
 
 on:
-  # push:
-  #   branches: [main]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/gate-count-pr.yml
+++ b/.github/workflows/gate-count-pr.yml
@@ -41,29 +41,56 @@ jobs:
           which nargo || echo "nargo not found in PATH"
           nargo --version || echo "nargo command failed"
 
+      - name: Save benchmark script to temp location
+        run: |
+          cp scripts/benchmark_gates.py /tmp/benchmark_gates.py
+          echo "Benchmark script saved to /tmp/benchmark_gates.py"
+
       - name: Run gate count benchmark on PR branch
         id: pr-benchmark
         run: |
-          python3 scripts/benchmark_gates.py --output /tmp/pr_gates.json
+          PR_COMMIT=$(git rev-parse HEAD | cut -c1-8)
+          echo "pr_commit=$PR_COMMIT" >> $GITHUB_OUTPUT
+          python3 /tmp/benchmark_gates.py --output /tmp/pr_gates.json
           echo "PR branch gate counts generated"
 
       - name: Checkout base branch
+        id: checkout-base
+        continue-on-error: true
         run: |
-          git fetch origin ${{ github.base_ref }}
-          git checkout origin/${{ github.base_ref }}
+          git fetch origin ${{ github.base_ref }} || exit 1
+          git checkout origin/${{ github.base_ref }} || exit 1
+          BASE_COMMIT=$(git rev-parse HEAD | cut -c1-8)
+          echo "base_commit=$BASE_COMMIT" >> $GITHUB_OUTPUT
 
       - name: Run gate count benchmark on base branch
         id: base-benchmark
+        if: steps.checkout-base.outcome == 'success'
         run: |
-          python3 scripts/benchmark_gates.py --output /tmp/base_gates.json
+          python3 /tmp/benchmark_gates.py --output /tmp/base_gates.json
           echo "Base branch gate counts generated"
+
+      - name: Create empty baseline if base branch doesn't exist
+        id: create-baseline
+        if: steps.checkout-base.outcome != 'success'
+        run: |
+          echo '{"timestamp": "baseline", "git_commit": "none", "benchmarks": {}}' > /tmp/base_gates.json
+          echo "base_commit=none" >> $GITHUB_OUTPUT
+          echo "Base branch not found, using empty baseline"
 
       - name: Compare gate counts and generate comment
         id: compare
+        env:
+          PR_COMMIT: ${{ steps.pr-benchmark.outputs.pr_commit }}
+          BASE_COMMIT: ${{ steps.checkout-base.outputs.base_commit || steps.create-baseline.outputs.base_commit || 'none' }}
         run: |
           python3 << 'EOF'
           import json
           import os
+          
+          # Get commits from environment
+          pr_commit = os.environ.get('PR_COMMIT', 'unknown')
+          base_commit = os.environ.get('BASE_COMMIT', 'unknown')
           
           # Load benchmark results
           with open('/tmp/pr_gates.json') as f:
@@ -79,8 +106,8 @@ jobs:
           
           # Generate markdown comment
           comment = "## 🔢 Gate Count Report\n\n"
-          comment += f"**PR Branch**: `{pr_results.get('git_commit', 'unknown')}`\n"
-          comment += f"**Base Branch**: `{base_results.get('git_commit', 'unknown')}`\n\n"
+          comment += f"**PR Branch**: `{pr_commit}`\n"
+          comment += f"**Base Branch**: `{base_commit}`\n\n"
           
           comment += "| Operation | Base ACIR | PR ACIR | Change | Base Brillig | PR Brillig | Change |\n"
           comment += "|-----------|-----------|---------|--------|--------------|------------|--------|\n"

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,0 +1,190 @@
+# Default agent for this repo when no workflow-specific agent is set.
+agent = 'codex'
+# Default model for this repo when no workflow-specific model is set.
+model = 'gpt-5.5'
+# Backup agent for this repo if the primary agent fails.
+backup_agent = ''
+# Backup model for this repo if the primary model fails.
+backup_model = ''
+# Number of related reviews to include as context for this repo.
+review_context_count = 0
+# Extra review instructions added to prompts for this repo.
+review_guidelines = ''
+# Override the review job timeout in minutes for this repo.
+job_timeout_minutes = 0
+# Branches that should be skipped for automatic review in this repo.
+excluded_branches = []
+# Commit message substrings that should skip review for this repo.
+excluded_commit_patterns = []
+# Display name shown for this repo in the TUI and output.
+display_name = ''
+# Reasoning level for reviews in this repo: fast, standard, medium, thorough, or maximum.
+review_reasoning = ''
+# Reasoning level for refine in this repo: fast, standard, medium, thorough, or maximum.
+refine_reasoning = ''
+# Reasoning level for fix in this repo: fast, standard, medium, thorough, or maximum.
+fix_reasoning = ''
+# Minimum severity for fix in this repo: critical, high, medium, or low.
+fix_min_severity = ''
+# Minimum severity for refine in this repo: critical, high, medium, low.
+refine_min_severity = ''
+# Minimum severity for reviews in this repo: critical, high, medium, low.
+review_min_severity = ''
+# Filenames or glob patterns to exclude from review diffs for this repo.
+exclude_patterns = []
+# Automatic post-commit review mode for this repo: commit or branch.
+post_commit_review = ''
+reuse_review_session_lookback = 0
+# Agent override for standard review in this repo.
+review_agent = 'codex'
+# Agent override for fast review in this repo.
+review_agent_fast = ''
+# Agent override for standard review in this repo.
+review_agent_standard = ''
+# Agent override for medium review in this repo.
+review_agent_medium = ''
+# Agent override for thorough review in this repo.
+review_agent_thorough = ''
+# Agent override for maximum review in this repo.
+review_agent_maximum = ''
+# Agent override for refine in this repo.
+refine_agent = ''
+# Agent override for fast refine in this repo.
+refine_agent_fast = ''
+# Agent override for standard refine in this repo.
+refine_agent_standard = ''
+# Agent override for medium refine in this repo.
+refine_agent_medium = ''
+# Agent override for thorough refine in this repo.
+refine_agent_thorough = ''
+# Agent override for maximum refine in this repo.
+refine_agent_maximum = ''
+# Model override for standard review in this repo.
+review_model = 'gpt-5.5'
+# Model override for fast review in this repo.
+review_model_fast = ''
+# Model override for standard review in this repo.
+review_model_standard = ''
+# Model override for medium review in this repo.
+review_model_medium = ''
+# Model override for thorough review in this repo.
+review_model_thorough = ''
+# Model override for maximum review in this repo.
+review_model_maximum = ''
+# Model override for standard refine in this repo.
+refine_model = ''
+# Model override for fast refine in this repo.
+refine_model_fast = ''
+# Model override for standard refine in this repo.
+refine_model_standard = ''
+# Model override for medium refine in this repo.
+refine_model_medium = ''
+# Model override for thorough refine in this repo.
+refine_model_thorough = ''
+# Model override for maximum refine in this repo.
+refine_model_maximum = ''
+# Agent override for fix in this repo.
+fix_agent = ''
+# Agent override for fast fix in this repo.
+fix_agent_fast = ''
+# Agent override for standard fix in this repo.
+fix_agent_standard = ''
+# Agent override for medium fix in this repo.
+fix_agent_medium = ''
+# Agent override for thorough fix in this repo.
+fix_agent_thorough = ''
+# Agent override for maximum fix in this repo.
+fix_agent_maximum = ''
+# Model override for standard fix in this repo.
+fix_model = ''
+# Model override for fast fix in this repo.
+fix_model_fast = ''
+# Model override for standard fix in this repo.
+fix_model_standard = ''
+# Model override for medium fix in this repo.
+fix_model_medium = ''
+# Model override for thorough fix in this repo.
+fix_model_thorough = ''
+# Model override for maximum fix in this repo.
+fix_model_maximum = ''
+# Agent override for security review in this repo.
+security_agent = ''
+# Agent override for fast security review in this repo.
+security_agent_fast = ''
+# Agent override for standard security review in this repo.
+security_agent_standard = ''
+# Agent override for medium security review in this repo.
+security_agent_medium = ''
+# Agent override for thorough security review in this repo.
+security_agent_thorough = ''
+# Agent override for maximum security review in this repo.
+security_agent_maximum = ''
+# Model override for standard security review in this repo.
+security_model = ''
+# Model override for fast security review in this repo.
+security_model_fast = ''
+# Model override for standard security review in this repo.
+security_model_standard = ''
+# Model override for medium security review in this repo.
+security_model_medium = ''
+# Model override for thorough security review in this repo.
+security_model_thorough = ''
+# Model override for maximum security review in this repo.
+security_model_maximum = ''
+# Agent override for design review in this repo.
+design_agent = ''
+# Agent override for fast design review in this repo.
+design_agent_fast = ''
+# Agent override for standard design review in this repo.
+design_agent_standard = ''
+# Agent override for medium design review in this repo.
+design_agent_medium = ''
+# Agent override for thorough design review in this repo.
+design_agent_thorough = ''
+# Agent override for maximum design review in this repo.
+design_agent_maximum = ''
+# Model override for standard design review in this repo.
+design_model = ''
+# Model override for fast design review in this repo.
+design_model_fast = ''
+# Model override for standard design review in this repo.
+design_model_standard = ''
+# Model override for medium design review in this repo.
+design_model_medium = ''
+# Model override for thorough design review in this repo.
+design_model_thorough = ''
+# Model override for maximum design review in this repo.
+design_model_maximum = ''
+# Backup agent for review in this repo.
+review_backup_agent = ''
+# Backup agent for refine in this repo.
+refine_backup_agent = ''
+# Backup agent for fix in this repo.
+fix_backup_agent = ''
+# Backup agent for security review in this repo.
+security_backup_agent = ''
+# Backup agent for design review in this repo.
+design_backup_agent = ''
+# Backup model for review in this repo.
+review_backup_model = ''
+# Backup model for refine in this repo.
+refine_backup_model = ''
+# Backup model for fix in this repo.
+fix_backup_model = ''
+# Backup model for security review in this repo.
+security_backup_model = ''
+# Backup model for design review in this repo.
+design_backup_model = ''
+hooks = []
+# Maximum prompt size for this repo before falling back to file paths.
+max_prompt_size = 0
+
+[ci]
+# Override the agents used by CI for this repo.
+agents = []
+# Override the review types used by CI for this repo.
+review_types = []
+# Override the CI reasoning level for this repo: fast, standard, medium, thorough, or maximum.
+reasoning = ''
+# Override the minimum CI severity included in synthesized output.
+min_severity = ''

--- a/.sync-manifest.json
+++ b/.sync-manifest.json
@@ -1,0 +1,17 @@
+{
+  "profile": "noir",
+  "ci_hooks": [
+    "generate-tests"
+  ],
+  "files": {
+    ".roborev.toml": "8e45a85b98fcaaa625c57cbc584a4826b7d0691bf729313932b462dca111c1a3",
+    ".github/noir-versions.json": "8bfc115aa4ad34f8e7715a4df76ccca454248a54b662a218795a7ea903348a45",
+    ".github/workflows/release.yml": "94ab10aa361839291eafaf2f2e86f425494beabb9683a67e3e236169091c6cf7",
+    ".github/workflows/gate-count-pr.yml": "32c11e0969445de00eb0844d199e0401a2715e66b023dbfc73da7ef5dd5f0a6b",
+    ".github/workflows/automerge.yml": "548ba3f7178aed11fb297da363dc2ce775126fd88d7de4e05deff94760fc1b50",
+    ".github/workflows/check-noir-version.yml": "db0648fc41095f02590deb6015f1b579bef23d9339ddbf42ac498bd5527c8e3c",
+    ".github/workflows/ci.yml": "f062d92f3934f52846be3466810fa35566e586a4d63fd909f31d58b0f4437c49",
+    ".github/workflows/gate-count-main.yml": "b0dcf3ab29c8876fd309a7075c13affe2edcab1bda25c230a5c1300f7234146a",
+    ".github/dependabot.yml": "6b87fd2bddf82475526be07c08cba7a9b897316db4559d3223d32cabb05856f3"
+  }
+}


### PR DESCRIPTION
## Summary

Propagates the canonical Noir-profile templates from `zkp-sparql-workspace/templates/sub-repo/noir/` into this repo, per phase 2 of the cross-repo consistency plan ([docs/cross-repo-consistency-plan.md §7](https://github.com/jeswr/zkp-sparql-workspace/blob/main/docs/cross-repo-consistency-plan.md)).

Files synced (all under `.github/` plus `.roborev.toml`):

- `.github/workflows/ci.yml` — **modified**. Adds the canonical documentation header identifying the file as workspace-rendered (`Source of truth: …templates/sub-repo/noir/.github/workflows/ci.yml.tmpl`).
- `.github/workflows/gate-count-main.yml` — **modified**. Restores the `on: push: branches: [main]` trigger that was a known regression here. The `noir_XPath` variant is canonical per consistency-plan §3 / `STABILISATION-TODOS.md` "Dead workflow triggers".
- `.github/workflows/gate-count-pr.yml` — **modified**. Adopts the `noir_XPath`-derived resilient variant (copies script to `/tmp` before checking out base branch; handles missing base branch).
- `.github/workflows/check-noir-version.yml` — **modified**. Picks up the two canonical-template fixes from workspace PR #1: `GH_TOKEN` PAT (so the bump PR triggers downstream CI) and `body-path:` rendering (so the `$(cat …)` interpolation actually runs).
- `.roborev.toml` — **new**. Now part of the managed canonical set.
- `.sync-manifest.json` — **new**. Phase-1 manifest with SHA-256 of every managed file; the future workspace drift-check workflow uses this to detect drift.

Profile: `noir`, `ci_hooks: [generate-tests]`.

This sync also resolves the `STABILISATION-TODOS.md` "Dead workflow triggers" entry for `gate-count-main.yml`'s commented-out `push:` trigger; that entry is being moved to *Resolved* in a separate workspace commit.

## Why a helper script

`scripts/sync-standards.sh` writes into the workspace's nested checkout of `circuits/noir_IEEE754`, not a per-PR worktree. To keep this PR self-contained we used a tiny phase-2 helper (`render-into-target.sh`) that mirrors the script's per-file rendering with a configurable target root. The helper reuses `scripts/render-template.py` and reproduces the same `.sync-manifest.json` shape, so a fresh `sync-standards.sh --dry-run` against this branch on `circuits/noir_IEEE754` reports zero drift.

## Test plan

- [x] `nargo check --workspace` — passes on this branch.
- [x] Diff is config-only — no `.nr` / `Nargo.toml` changes.
- [ ] CI matrix should run as before; the `ci.yml` change is documentation-header only (modulo the canonical's IEEE754-shape, which already matches this repo verbatim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)