### PR TITLE
fix(tests): align SNaN encoding to library canonical (C.3)

### DIFF
--- a/scripts/noir_ieee754_inputs/fptest.py
+++ b/scripts/noir_ieee754_inputs/fptest.py
@@ -181,13 +181,19 @@ def fp_value_to_bits(val: FPValue, is_float32: bool = True) -> int:
     """
     if val.is_nan:
         if val.is_snan:
-            # Legacy "low-bit payload" SNaN encoding the generator has always
-            # emitted; the Noir library uses 0x7FA00000 / 0x7FF4_..._0000
-            # instead. Both are valid SNaN per IEEE 754-2019 sec 6.2.1; the
-            # design doc tracks the alignment as an open question (Q.C.3),
-            # so this round preserves byte-for-byte parity with previous
-            # generator output.
-            return 0x7F800001 if is_float32 else 0x7FF0000000000001
+            # Library-canonical SNaN encoding (decision C.3, 2026-05-03):
+            # ``FLOAT32_SIGNALING_NAN`` / ``FLOAT64_SIGNALING_NAN`` are the
+            # exact bit patterns the Noir library produces from its own
+            # SNaN-handling paths, so emitting them here keeps the generator
+            # and the library aligned. NaN-result tests assert via
+            # ``floatN_is_nan`` and therefore do not depend on this choice;
+            # SNaN *operand* encodings now match the library so quietened
+            # expectations (e.g. ``S * x -> qNaN``) round-trip cleanly.
+            return (
+                constants.FLOAT32_SIGNALING_NAN
+                if is_float32
+                else constants.FLOAT64_SIGNALING_NAN
+            )
         return constants.FLOAT32_NAN if is_float32 else constants.FLOAT64_NAN
     if val.is_inf:
         if is_float32:


### PR DESCRIPTION
## Summary

Implements decision **C.3 (2026-05-03)** from `docs/ieee754-input-prep-redesign.md` §7.3: the Noir library is canonical for SNaN encoding (`0x7FA00000` for binary32, `0x7FF4000000000000` for binary64), and the test generator now emits the same.

`fp_value_to_bits` returns `FLOAT32_SIGNALING_NAN` / `FLOAT64_SIGNALING_NAN` for any operand or expected result with `is_snan=True`, replacing the legacy "low-bit payload" form (`0x7F800001` / `0x7FF0000000000001`) the generator had emitted to keep PR #38 byte-identical. Both encodings are valid per IEEE 754-2019 sec 6.2.1 -- this just aligns the two ends.

NaN-result assertions are unaffected: PR #38 already switched every NaN-result expectation to `floatN_is_nan(result)`, so the SNaN-encoding flip is opaque to test pass/fail.

## Impact on the regenerated test fixtures

- 356 emitted SNaN literal sites flip from `0x7F800001` to `FLOAT32_SIGNALING_NAN` (rendered through `render_special_or_hex` since the constant has shipped since PR #38).
- No emitted f64 sites change -- the IBM FPgen suite has no f64 signaling-NaN operands in the generator's current input slice.
- Test count is unchanged (77 850 across 16 packages, 73 chunked packages).
- `.github/test-matrix.json` regenerates byte-identical.

## Test plan

- [x] `nargo check --workspace` -- clean (only the pre-existing `ROUNDING_MODE_TOWARD_ZERO` unused-import warning).
- [x] `nargo test --workspace` -- 170/170 unit tests green.
- [x] Regenerated `ieee754_test_input_special_significand_part0` (1250 tests, only package containing SNaN operands) -- green against the new fixtures.
- [x] `python3 scripts/generate_tests.py --all --packages --synthetic-f64 --generate-f64 --output-dir test_packages --ci-matrix .github/test-matrix.json` -- matrix byte-identical to checked-in copy.
- [x] roborev review (codex / gpt-5.5) -- "No issues found".