### PR TITLE
feat(circuits): shift_right_sticky_u64_verified -- MIXED verdict, primitive shipped, no swap

### DIFF
--- a/bench/SPIKES.md
+++ b/bench/SPIKES.md
@@ -253,18 +253,26 @@ Two angles worth measuring in a future spike, *not* this one:
 
 ### Process
 
-- Four commits on the branch: source-level primitive (`9c1f8cb` after
+- Five commits on the branch: source-level primitive (`9c1f8cb` after
   rebase onto `e6d7107`), adversarial test follow-up (`0f497e5`)
   addressing roborev's flagged `shift>=64 sticky direction wrong` test
-  gap, benchmark harness (`2b563e5`), and harness-comment + primitive
-  comparison (`2c4f142`) addressing the second roborev round, then this
-  ledger update.
+  gap, benchmark harness (`2b563e5`), harness-comment + primitive
+  comparison (`2c4f142`) addressing the second roborev round, this
+  ledger update, then a follow-up commit regenerating the JSON against
+  the SPIKES commit.
 - 36 ieee754 tests passed (15 baseline + 21 new shr_sticky tests, of
   which 11 happy-path + 10 adversarial).
 - Roborev (codex / gpt-5.5) returned "No issues found" on the
   adversarial-test commit and on the harness-improvement commit;
   earlier roborev rounds raised the test-gap and stale-`git_commit`
   findings that those commits closed.
+
+**Provenance note.** The committed JSON's `git_commit` field points at
+the *parent* of the JSON's commit (the harness used to capture it can't
+know its own commit hash before commit). After every bench run, the
+recorded `git_commit` is therefore the most recent commit at run time;
+to interpret a number against a future repo state, look at the
+`git_commit` field plus the commit that introduced the JSON itself.
 
 ---
 

--- a/bench/SPIKES.md
+++ b/bench/SPIKES.md
@@ -147,6 +147,127 @@ the noir-optimisation skill's section 3.3.
 
 ---
 
+## 2026-05-03 -- `shr_sticky_u64` Euclidean-division verifier
+
+**Verdict:** **MIXED.** Verifier wins -5 Width / -7% in both regimes
+but loses +103 ACIR / +303% in both; per the workspace rule
+"Width is what the prover pays for under Barretenberg" the trade is
+not strong enough to justify swapping call sites, so the primitive ships
+as a stable public-API target only.
+
+**Branch:** `feat/shr-sticky-u64-verified` (this PR; primitive +
+benchmarks shipped, no call sites swapped).
+
+**Toolchain:** `nargo 1.0.0-beta.17` on macOS, against `origin/main` at
+`22dafd9` (post-PR #41 CI sync, post-PR #40 `clz_u64` deletion).
+
+### Motivation
+
+The first-round task asked: do the cost numbers for
+`shift_right_sticky_u64_verified` look like `clz_u64`'s (regress on both
+metrics, drop) or do they pay off? The relation shape is genuinely
+different -- Euclidean-division reconstruction
+`value = quotient * (1 << shift) + remainder` over `Field` plus an
+existence-of-inverse witness for the sticky-direction clause -- so the
+empirical answer was unknown until measurement.
+
+### Constraint shape
+
+For `shift == 0` and `shift >= 64` the verifier short-circuits to direct
+equality / inequality assertions (cheap). For `1 <= shift <= 63`:
+
+| Clause   | Constraint                                                                     |
+|----------|--------------------------------------------------------------------------------|
+| (3a)     | `value == quotient * pow2 + remainder` over `Field` (pow2 = `1 << shift`)      |
+| (3b)     | `remainder < pow2` (range check on a u64 difference)                           |
+| (3c.i)   | `(1 - sticky) * remainder == 0`  (`sticky == 0 => remainder == 0`)             |
+| (3c.ii)  | `remainder * remainder_inv == sticky` with witnessed `remainder_inv: Field`    |
+
+Plus one dynamic left-shift `1 << shift`. The baseline does two dynamic
+shifts (`>> shift` and `1 << shift` for the mask), so the verifier nets
+out *one fewer dynamic shift* in exchange for one Field multiplication
+and the boolean-direction pinning.
+
+### Numbers
+
+Measured by `scripts/benchmark_gates.py`'s `PRIMITIVE_BENCHMARKS`,
+isolated regime (verifier on its own, `(value, shift)` as `pub u64` to
+defeat constant-folding) and composed regime (the `denorm_shift < 56`
+denormal-mantissa shift block from `float64/mul.nr` line 303). Both
+variants measured in the same run.
+
+| Variant                                | Width | ACIR |
+|----------------------------------------|------:|-----:|
+| `shr_sticky_u64_isolated_baseline`     |    72 |   34 |
+| `shr_sticky_u64_isolated_verified`     |    67 |  137 |
+| `shr_sticky_u64_composed_baseline`     |   106 |   34 |
+| `shr_sticky_u64_composed_verified`     |   101 |  137 |
+
+Verifier delta: **-5 Width (-7%) / +103 ACIR (+303%)** in both regimes.
+The composed delta is exactly the same as the isolated delta, so the
+regression is structural (not a constant-folding artefact in the
+isolated harness).
+
+### Why the trade looks like this
+
+The verifier saves one dynamic shift relative to the baseline (the
+baseline computes both `(1 << shift) - 1` for the mask AND `value >>
+shift` for the quotient; the verifier computes only `1 << shift` for
+`pow2`). That's the -5 Width win.
+
+But the verifier adds: a Field multiplication `quotient * pow2`, a
+Field equality, two boolean-direction constraints, plus the `Field`
+inverse witness's multiplicative constraint. Each of those is small in
+Width but adds an `AssertZero` ACIR opcode -- hence the +103 ACIR
+regression.
+
+Comparison to the `clz_u64` round (PR #37, deleted in PR #40): clz_u64
+regressed on **both** Width AND ACIR; this primitive regresses only on
+ACIR. The difference is the relation shape -- Euclidean-division has
+constant-multiplier structure (the `pow2` multiplier is small relative
+to the BN254 modulus, so the Field multiplication has narrow expression
+width); CLZ's two dynamic shifts contribute to Width additively.
+
+### Implication for follow-on work
+
+The Width edge is too small (-7%) to motivate swapping call sites: if a
+future Lampe extraction round needs the verified-relation shape (because
+the soundness proof depends on the algebraic relation rather than the
+binary-search baseline's straight-line shifts), the primitive is
+available. Otherwise, the in-tree `utils::shift_right_sticky_u64` is the
+right choice.
+
+Two angles worth measuring in a future spike, *not* this one:
+
+- **Constant-shift call site.** The float32/mul.nr line 201 call has
+  `guard_shift = 46 - 26 = 20` known at compile time; the verifier's
+  `1 << shift` would constant-fold and the relation might collapse to
+  cheaper-than-baseline. A focused `shr_sticky_u64_const20_*` benchmark
+  would answer this; if the verifier wins by enough Width there, swap
+  *that* call site only.
+
+- **`shr_sticky_u128`.** The float64/mul.nr line 281 call uses the U128
+  variant. Its in-circuit baseline is more complex; a U128 verified
+  variant could plausibly win where the u64 one only marginally does.
+  Out of scope for this round.
+
+### Process
+
+- Four commits on the branch: source-level primitive (`9c1f8cb` after
+  rebase onto `e6d7107`), adversarial test follow-up (`0f497e5`)
+  addressing roborev's flagged `shift>=64 sticky direction wrong` test
+  gap, benchmark harness (`2b563e5`), and harness-comment + primitive
+  comparison (`2c4f142`) addressing the second roborev round, then this
+  ledger update.
+- 36 ieee754 tests passed (15 baseline + 21 new shr_sticky tests, of
+  which 11 happy-path + 10 adversarial).
+- Roborev (codex / gpt-5.5) returned "No issues found" on the
+  adversarial-test commit and on the harness-improvement commit;
+  earlier roborev rounds raised the test-gap and stale-`git_commit`
+  findings that those commits closed.
+
+---
+
 ## Template
 
 ```

--- a/bench/SPIKES.md
+++ b/bench/SPIKES.md
@@ -253,13 +253,14 @@ Two angles worth measuring in a future spike, *not* this one:
 
 ### Process
 
-- Five commits on the branch: source-level primitive (`9c1f8cb` after
+- Six commits on the branch: source-level primitive (`9c1f8cb` after
   rebase onto `e6d7107`), adversarial test follow-up (`0f497e5`)
   addressing roborev's flagged `shift>=64 sticky direction wrong` test
   gap, benchmark harness (`2b563e5`), harness-comment + primitive
-  comparison (`2c4f142`) addressing the second roborev round, this
-  ledger update, then a follow-up commit regenerating the JSON against
-  the SPIKES commit.
+  comparison (`2c4f142`) addressing the second roborev round, the
+  initial SPIKES + JSON ledger commit (`b8724f4`), and a follow-up
+  ledger refresh + provenance-note commit (`deb9b32`) addressing
+  roborev's stale-`git_commit` finding on the prior commit.
 - 36 ieee754 tests passed (15 baseline + 21 new shr_sticky tests, of
   which 11 happy-path + 10 adversarial).
 - Roborev (codex / gpt-5.5) returned "No issues found" on the

--- a/bench/unconstrained_gate_counts.json
+++ b/bench/unconstrained_gate_counts.json
@@ -1,63 +1,7 @@
 [
   {
-    "timestamp": "2026-05-03T15:53:27.957917",
-    "git_commit": "44ec2fca",
-    "benchmarks": {
-      "add_float32": {
-        "expression_width": 610,
-        "acir_opcodes": 34
-      },
-      "mul_float32": {
-        "expression_width": 1053,
-        "acir_opcodes": 34
-      },
-      "sub_float32": {
-        "expression_width": 611,
-        "acir_opcodes": 34
-      },
-      "div_float32": {
-        "expression_width": 959,
-        "acir_opcodes": 34
-      },
-      "add_float64": {
-        "expression_width": 714,
-        "acir_opcodes": 34
-      },
-      "mul_float64": {
-        "expression_width": 1783,
-        "acir_opcodes": 34
-      },
-      "sub_float64": {
-        "expression_width": 715,
-        "acir_opcodes": 34
-      },
-      "div_float64": {
-        "expression_width": 4589,
-        "acir_opcodes": 34
-      }
-    },
-    "primitive_benchmarks": {
-      "shr_sticky_u64_isolated_verified": {
-        "expression_width": 67,
-        "acir_opcodes": 137
-      },
-      "shr_sticky_u64_isolated_baseline": {
-        "expression_width": 72,
-        "acir_opcodes": 34
-      },
-      "shr_sticky_u64_composed_verified": {
-        "expression_width": 101,
-        "acir_opcodes": 137
-      },
-      "shr_sticky_u64_composed_baseline": {
-        "expression_width": 106,
-        "acir_opcodes": 34
-      }
-    }
-  },
-  {
-    "timestamp": "2026-05-03T15:59:31.253573",
-    "git_commit": "a339a40d",
+    "timestamp": "2026-05-03T16:07:22.804959",
+    "git_commit": "2c4f1424",
     "benchmarks": {
       "add_float32": {
         "expression_width": 610,

--- a/bench/unconstrained_gate_counts.json
+++ b/bench/unconstrained_gate_counts.json
@@ -1,7 +1,7 @@
 [
   {
-    "timestamp": "2026-05-03T16:07:22.804959",
-    "git_commit": "2c4f1424",
+    "timestamp": "2026-05-03T16:09:00.331969",
+    "git_commit": "b8724f43",
     "benchmarks": {
       "add_float32": {
         "expression_width": 610,

--- a/bench/unconstrained_gate_counts.json
+++ b/bench/unconstrained_gate_counts.json
@@ -1,0 +1,114 @@
+[
+  {
+    "timestamp": "2026-05-03T15:53:27.957917",
+    "git_commit": "44ec2fca",
+    "benchmarks": {
+      "add_float32": {
+        "expression_width": 610,
+        "acir_opcodes": 34
+      },
+      "mul_float32": {
+        "expression_width": 1053,
+        "acir_opcodes": 34
+      },
+      "sub_float32": {
+        "expression_width": 611,
+        "acir_opcodes": 34
+      },
+      "div_float32": {
+        "expression_width": 959,
+        "acir_opcodes": 34
+      },
+      "add_float64": {
+        "expression_width": 714,
+        "acir_opcodes": 34
+      },
+      "mul_float64": {
+        "expression_width": 1783,
+        "acir_opcodes": 34
+      },
+      "sub_float64": {
+        "expression_width": 715,
+        "acir_opcodes": 34
+      },
+      "div_float64": {
+        "expression_width": 4589,
+        "acir_opcodes": 34
+      }
+    },
+    "primitive_benchmarks": {
+      "shr_sticky_u64_isolated_verified": {
+        "expression_width": 67,
+        "acir_opcodes": 137
+      },
+      "shr_sticky_u64_isolated_baseline": {
+        "expression_width": 72,
+        "acir_opcodes": 34
+      },
+      "shr_sticky_u64_composed_verified": {
+        "expression_width": 101,
+        "acir_opcodes": 137
+      },
+      "shr_sticky_u64_composed_baseline": {
+        "expression_width": 106,
+        "acir_opcodes": 34
+      }
+    }
+  },
+  {
+    "timestamp": "2026-05-03T15:59:31.253573",
+    "git_commit": "a339a40d",
+    "benchmarks": {
+      "add_float32": {
+        "expression_width": 610,
+        "acir_opcodes": 34
+      },
+      "mul_float32": {
+        "expression_width": 1053,
+        "acir_opcodes": 34
+      },
+      "sub_float32": {
+        "expression_width": 611,
+        "acir_opcodes": 34
+      },
+      "div_float32": {
+        "expression_width": 959,
+        "acir_opcodes": 34
+      },
+      "add_float64": {
+        "expression_width": 714,
+        "acir_opcodes": 34
+      },
+      "mul_float64": {
+        "expression_width": 1783,
+        "acir_opcodes": 34
+      },
+      "sub_float64": {
+        "expression_width": 715,
+        "acir_opcodes": 34
+      },
+      "div_float64": {
+        "expression_width": 4589,
+        "acir_opcodes": 34
+      }
+    },
+    "primitive_benchmarks": {
+      "shr_sticky_u64_isolated_verified": {
+        "expression_width": 67,
+        "acir_opcodes": 137
+      },
+      "shr_sticky_u64_isolated_baseline": {
+        "expression_width": 72,
+        "acir_opcodes": 34
+      },
+      "shr_sticky_u64_composed_verified": {
+        "expression_width": 101,
+        "acir_opcodes": 137
+      },
+      "shr_sticky_u64_composed_baseline": {
+        "expression_width": 106,
+        "acir_opcodes": 34
+      }
+    }
+  }
+]

--- a/ieee754/src/lib.nr
+++ b/ieee754/src/lib.nr
@@ -5,7 +5,9 @@ pub mod float64;
 pub mod float;
 pub mod unconstrained_ops;
 
-pub use crate::unconstrained_ops::count_leading_zeros_u23_verified;
+pub use crate::unconstrained_ops::{
+    count_leading_zeros_u23_verified, shift_right_sticky_u64_verified,
+};
 
 // Re-export public API
 pub use crate::float::{

--- a/ieee754/src/unconstrained_ops.nr
+++ b/ieee754/src/unconstrained_ops.nr
@@ -716,6 +716,17 @@ fn test_shr_sticky_u64_bad_sticky_zero_shift_64() {
     verify_shr_sticky_u64_relation(0xABCD_u64, 64_u64, 0_u64, 0xABCD_u64, 0_u1);
 }
 
+#[test(should_fail_with = "shift>=64 sticky direction wrong")]
+fn test_shr_sticky_u64_bad_sticky_one_value_zero_shift_64() {
+    // shift == 64, value == 0, sticky claimed 1 -- rejected by the
+    // existence-of-inverse clause `value * value_inv == sticky` (0 * inv == 0
+    // != 1). This isolates the second sticky-direction constraint in the
+    // shift >= 64 branch (mirrors the `< 64` adversarial test
+    // `bad_sticky_one_with_zero_remainder`).
+    // Safety: adversarial path.
+    verify_shr_sticky_u64_relation(0_u64, 64_u64, 0_u64, 0_u64, 1_u1);
+}
+
 #[test]
 fn test_shr_sticky_u64_shift_far_above_64() {
     // Drop-in compatibility with the baseline: very large shifts collapse to

--- a/ieee754/src/unconstrained_ops.nr
+++ b/ieee754/src/unconstrained_ops.nr
@@ -361,10 +361,7 @@ fn test_clz_u23_hint_bit_above_fails() {
 /// Crate-private deliberately: a downstream caller must not be able to bypass
 /// the verifier by importing the raw hint. The only sanctioned consumer is
 /// `shift_right_sticky_u64_verified` immediately below.
-unconstrained fn shift_right_sticky_u64_unconstrained(
-    value: u64,
-    shift: u64,
-) -> (u64, u64, u1) {
+unconstrained fn shift_right_sticky_u64_unconstrained(value: u64, shift: u64) -> (u64, u64, u1) {
     if shift == 0_u64 {
         (value, 0_u64, 0_u1)
     } else if shift >= 64_u64 {
@@ -507,10 +504,7 @@ fn verify_shr_sticky_u64_relation(
         );
 
         // Clause (3b): remainder < pow2. Both sides are u64 here.
-        assert(
-            remainder < pow2,
-            "shift_right_sticky_u64: remainder above pow2",
-        );
+        assert(remainder < pow2, "shift_right_sticky_u64: remainder above pow2");
 
         // Clause (3c): sticky direction -- pinned by two constraints plus a
         // witnessed Field inverse hint.

--- a/ieee754/src/unconstrained_ops.nr
+++ b/ieee754/src/unconstrained_ops.nr
@@ -330,3 +330,397 @@ fn test_clz_u23_hint_bit_above_fails() {
     let count: u32 = 17_u32;
     let _ = verify_clz_u23_relation(value, count);
 }
+// ============================================================================
+// shift_right_sticky_u64
+// ============================================================================
+
+/// Brillig hint: compute the quotient, remainder, and sticky bit of the
+/// "right shift with sticky" operation on a 64-bit value.
+///
+/// Given `value: u64` and `shift: u64`, returns `(quotient, remainder, sticky)`
+/// such that:
+///
+/// - if `shift == 0`: `quotient == value`, `remainder == 0`, `sticky == 0`;
+/// - if `1 <= shift <= 63`: `quotient == value >> shift`,
+///   `remainder == value & ((1 << shift) - 1)`,
+///   `sticky == (remainder != 0) as u1`;
+/// - if `shift >= 64`: `quotient == 0`, `remainder == value`,
+///   `sticky == (value != 0) as u1`.
+///
+/// The combined return shape mirrors the existing in-circuit
+/// `shift_right_sticky_u64(value, shift)` baseline, which encodes the result
+/// as `quotient | (sticky as u64)` after the shift. Returning the raw
+/// `(quotient, remainder, sticky)` triple from the unconstrained hint lets the
+/// verifier check the algebraic relation directly and lets the wrapper
+/// recombine the encoded result.
+///
+/// This function is `unconstrained` and contributes no ACIR gates. Its output
+/// MUST be validated by `shift_right_sticky_u64_verified` before being
+/// trusted.
+///
+/// Crate-private deliberately: a downstream caller must not be able to bypass
+/// the verifier by importing the raw hint. The only sanctioned consumer is
+/// `shift_right_sticky_u64_verified` immediately below.
+unconstrained fn shift_right_sticky_u64_unconstrained(
+    value: u64,
+    shift: u64,
+) -> (u64, u64, u1) {
+    if shift == 0_u64 {
+        (value, 0_u64, 0_u1)
+    } else if shift >= 64_u64 {
+        let sticky: u1 = if value != 0_u64 { 1_u1 } else { 0_u1 };
+        (0_u64, value, sticky)
+    } else {
+        // 1 <= shift <= 63 here.
+        let mask: u64 = (1_u64 << shift) - 1_u64;
+        let remainder: u64 = value & mask;
+        let quotient: u64 = value >> shift;
+        let sticky: u1 = if remainder != 0_u64 { 1_u1 } else { 0_u1 };
+        (quotient, remainder, sticky)
+    }
+}
+
+/// Constrained verifier: returns the right-shifted-with-sticky encoding of
+/// `value` by `shift`, asserting the relation that uniquely pins the witnessed
+/// quotient, remainder and sticky bit.
+///
+/// # Public-input contract
+/// - Input: `value: u64`, `shift: u64`.
+/// - Output: `u64` matching the in-tree `shift_right_sticky_u64(value, shift)`
+///   baseline, namely `quotient | (sticky as u64)`.
+///
+/// # SAFETY PROOF (sketch -- not mechanised)
+///
+/// The verifier asserts the relation `R(value, shift, quotient, remainder, sticky)`:
+///
+/// 1. **`shift == 0` case**: `quotient == value`, `remainder == 0`,
+///    `sticky == 0`.
+/// 2. **`shift >= 64` case** (`shift` interpreted as a u64; we require the
+///    caller's high bits of `shift` to be zero, i.e. `shift <= 64` here for
+///    the verifier to make sense): `quotient == 0`, `remainder == value`,
+///    `sticky == (value != 0)`.
+/// 3. **`1 <= shift <= 63` case**, with `pow2 := 1 << shift`:
+///      a. **Reconstruction**:
+///         `value == quotient * pow2 + remainder` (over `Field`, so no u64
+///         wrap).
+///      b. **Bound**: `remainder < pow2`.
+///      c. **Sticky direction**:
+///         - `(1 - sticky) * remainder == 0` (i.e. `sticky == 0 => remainder == 0`);
+///         - there exists a witnessed `remainder_inv: Field` with
+///           `remainder * remainder_inv == sticky as Field` (i.e.
+///           `remainder != 0 => sticky == 1`).
+/// 4. `sticky in {0, 1}` (encoded by the `u1` type at the witness boundary).
+///
+/// We deliberately accept any `shift: u64` (not just `shift <= 64`) to match
+/// the in-tree `shift_right_sticky_u64(value, shift)` baseline's
+/// drop-in semantics; any `shift >= 64` collapses to the "all bits shifted
+/// out" case, which the verifier handles uniformly.
+///
+/// **Uniqueness** of `(quotient, remainder, sticky)` for a fixed
+/// `(value, shift)`:
+///
+/// - `shift == 0` and `shift >= 64` cases have only one solution by the
+///   conditions stated.
+/// - `1 <= shift <= 63` case: clauses (3a) + (3b) are the standard Euclidean
+///   division of `value` by `pow2`, which uniquely determines `(quotient,
+///   remainder)`. Clause (3c) then uniquely determines `sticky`:
+///   if `remainder == 0` the inverse witness forces `sticky == 0` via
+///   `0 * inv == sticky`, and the `(1 - sticky) * remainder == 0` clause is
+///   trivially satisfied; if `remainder != 0` the `(1 - sticky) * remainder
+///   == 0` clause forces `sticky == 1`, and the inverse witness must equal
+///   `remainder^{-1}` to satisfy the multiplicative clause.
+///
+/// **Correctness**: by definition of right-shift-with-sticky on a 64-bit
+/// register, the spec is the encoding above; clauses (1)/(2)/(3) implement
+/// exactly this definition, matching the Lean spec `Spec.shr_sticky_u64` in
+/// `proofs/Ieee754/.../UnconstrainedOps.lean`.
+///
+/// This sketch is a reading aid; the soundness has not been mechanised
+/// (the `shr_sticky_u64_unique` and `shr_sticky_u64_correct` Lean obligations
+/// remain `sorry`-stubbed).
+pub fn shift_right_sticky_u64_verified(value: u64, shift: u64) -> u64 {
+    // Safety: `verify_shr_sticky_u64_relation` enforces the relation that
+    // uniquely pins `(quotient, remainder, sticky)`; see SAFETY PROOF above.
+    let (quotient, remainder, sticky): (u64, u64, u1) =
+        unsafe { shift_right_sticky_u64_unconstrained(value, shift) };
+    verify_shr_sticky_u64_relation(value, shift, quotient, remainder, sticky);
+    quotient | (sticky as u64)
+}
+
+/// Constrained relation check shared by `shift_right_sticky_u64_verified`
+/// and the adversarial tests. Asserts the SAFETY PROOF clauses and returns
+/// nothing (the caller already has `quotient`, `remainder`, `sticky`).
+///
+/// Private to this module so the assertion error strings remain
+/// implementation details. Sharing the helper between production and tests
+/// means an adversarial-test failure also flags a regression in the
+/// production verifier path.
+fn verify_shr_sticky_u64_relation(
+    value: u64,
+    shift: u64,
+    quotient: u64,
+    remainder: u64,
+    sticky: u1,
+) {
+    if shift == 0_u64 {
+        // Clause (1): no shift -- quotient is value, no bits shifted out.
+        assert(quotient == value, "shift_right_sticky_u64: shift==0 quotient mismatch");
+        assert(remainder == 0_u64, "shift_right_sticky_u64: shift==0 remainder nonzero");
+        assert(sticky == 0_u1, "shift_right_sticky_u64: shift==0 sticky set");
+    } else if shift >= 64_u64 {
+        // Clause (2): all bits shifted out -- quotient is 0, remainder is the
+        // entire value, sticky tracks whether anything was shifted out.
+        assert(quotient == 0_u64, "shift_right_sticky_u64: shift>=64 quotient nonzero");
+        assert(remainder == value, "shift_right_sticky_u64: shift>=64 remainder mismatch");
+        // sticky == (value != 0): use the existence-of-inverse trick.
+        let value_f: Field = value as Field;
+        let sticky_f: Field = sticky as Field;
+        // (1 - sticky) * value == 0  : sticky == 0 => value == 0.
+        assert(
+            (1_u64 - (sticky as u64)) as Field * value_f == 0,
+            "shift_right_sticky_u64: shift>=64 sticky==0 but value nonzero",
+        );
+        // value * value_inv == sticky : value != 0 => sticky == 1.
+        // Witness `value_inv` via the unconstrained inverse hint.
+        let value_inv: Field = unsafe { field_inv_or_zero(value_f) };
+        assert(
+            value_f * value_inv == sticky_f,
+            "shift_right_sticky_u64: shift>=64 sticky direction wrong",
+        );
+    } else {
+        // Clause (3): 1 <= shift <= 63.
+        //
+        // pow2 = 1 << shift, in [2, 2^63]. The shift amount type matches the
+        // LHS u64 width per Noir 1.0.0-beta.17 typing rules; the upper bits
+        // of `shift` are zero by the case guard.
+        let pow2: u64 = 1_u64 << shift;
+
+        // Clause (3a): reconstruction over Field (avoids u64 wrap on the
+        // product `quotient * pow2`, which can be up to 2^64 * 2^63 = 2^127).
+        let value_f: Field = value as Field;
+        let quotient_f: Field = quotient as Field;
+        let pow2_f: Field = pow2 as Field;
+        let remainder_f: Field = remainder as Field;
+        assert(
+            value_f == quotient_f * pow2_f + remainder_f,
+            "shift_right_sticky_u64: reconstruction failed",
+        );
+
+        // Clause (3b): remainder < pow2. Both sides are u64 here.
+        assert(
+            remainder < pow2,
+            "shift_right_sticky_u64: remainder above pow2",
+        );
+
+        // Clause (3c): sticky direction -- pinned by two constraints plus a
+        // witnessed Field inverse hint.
+        let sticky_f: Field = sticky as Field;
+        // (1 - sticky) * remainder == 0 : sticky == 0 => remainder == 0.
+        assert(
+            (1_u64 - (sticky as u64)) as Field * remainder_f == 0,
+            "shift_right_sticky_u64: sticky==0 but remainder nonzero",
+        );
+        // remainder * remainder_inv == sticky : remainder != 0 => sticky == 1.
+        let remainder_inv: Field = unsafe { field_inv_or_zero(remainder_f) };
+        assert(
+            remainder_f * remainder_inv == sticky_f,
+            "shift_right_sticky_u64: sticky direction wrong",
+        );
+    }
+}
+
+/// Brillig hint: returns the multiplicative inverse of `x` in the Field, or
+/// `0` if `x == 0`. The verifier never trusts this output -- it merely uses
+/// it as a witness in the `x * x_inv == indicator` constraint pattern that
+/// pins the indicator to `(x != 0)`.
+///
+/// Crate-private. Sanctioned consumers: the `verify_shr_sticky_u64_relation`
+/// verifier above.
+unconstrained fn field_inv_or_zero(x: Field) -> Field {
+    if x == 0 {
+        0
+    } else {
+        1 / x
+    }
+}
+
+// ============================================================================
+// Tests -- happy paths (shr_sticky_u64)
+// ============================================================================
+
+#[test]
+fn test_shr_sticky_u64_zero_shift() {
+    let result: u64 = shift_right_sticky_u64_verified(0xDEAD_BEEF_u64, 0_u64);
+    assert(result == 0xDEAD_BEEF_u64);
+}
+
+#[test]
+fn test_shr_sticky_u64_zero_value() {
+    // Shifting zero by anything is zero with no sticky.
+    let result: u64 = shift_right_sticky_u64_verified(0_u64, 5_u64);
+    assert(result == 0_u64);
+    let result_big: u64 = shift_right_sticky_u64_verified(0_u64, 64_u64);
+    assert(result_big == 0_u64);
+    let result_huge: u64 = shift_right_sticky_u64_verified(0_u64, 100_u64);
+    assert(result_huge == 0_u64);
+}
+
+#[test]
+fn test_shr_sticky_u64_clean_shift() {
+    // 0b1000 >> 3 == 1, no bits shifted out, sticky == 0.
+    let result: u64 = shift_right_sticky_u64_verified(8_u64, 3_u64);
+    assert(result == 1_u64);
+}
+
+#[test]
+fn test_shr_sticky_u64_with_sticky() {
+    // 0b1011 >> 2 == 0b10 (= 2), bits 1..0 == 0b11 shifted out so sticky == 1.
+    // Encoded result: quotient | sticky = 0b10 | 1 = 0b11 = 3.
+    let result: u64 = shift_right_sticky_u64_verified(11_u64, 2_u64);
+    assert(result == 3_u64);
+}
+
+#[test]
+fn test_shr_sticky_u64_shift_one_clean() {
+    // 0b10 >> 1 == 1, bit 0 == 0, sticky == 0.
+    let result: u64 = shift_right_sticky_u64_verified(2_u64, 1_u64);
+    assert(result == 1_u64);
+}
+
+#[test]
+fn test_shr_sticky_u64_shift_one_dirty() {
+    // 0b11 >> 1 == 1, bit 0 == 1, sticky == 1; encoded == 1 | 1 == 1.
+    let result: u64 = shift_right_sticky_u64_verified(3_u64, 1_u64);
+    assert(result == 1_u64);
+}
+
+#[test]
+fn test_shr_sticky_u64_shift_63() {
+    // value = 1 << 63: quotient = 1, remainder = 0, sticky = 0.
+    let value: u64 = 1_u64 << 63_u64;
+    let result: u64 = shift_right_sticky_u64_verified(value, 63_u64);
+    assert(result == 1_u64);
+}
+
+#[test]
+fn test_shr_sticky_u64_shift_63_with_sticky() {
+    // value = (1 << 63) | 1: quotient = 1, remainder = 1, sticky = 1.
+    // Encoded = 1 | 1 == 1.
+    let value: u64 = (1_u64 << 63_u64) | 1_u64;
+    let result: u64 = shift_right_sticky_u64_verified(value, 63_u64);
+    assert(result == 1_u64);
+}
+
+#[test]
+fn test_shr_sticky_u64_shift_64_nonzero() {
+    // shift == 64: everything shifted out. Quotient = 0, remainder = value,
+    // sticky = (value != 0) = 1; encoded == 0 | 1 == 1.
+    let result: u64 = shift_right_sticky_u64_verified(0xDEAD_BEEF_u64, 64_u64);
+    assert(result == 1_u64);
+}
+
+#[test]
+fn test_shr_sticky_u64_matches_baseline_clean() {
+    // Cross-check against the in-tree baseline on a dirty mid-shift case.
+    // value = 0xABCD_EF01_u64, shift = 12: quotient = 0xABCDE, remainder =
+    // 0xF01 != 0 so sticky = 1. Encoded = 0xABCDE | 1 = 0xABCDF.
+    let value: u64 = 0xABCD_EF01_u64;
+    let baseline: u64 = crate::utils::shift_right_sticky_u64(value, 12_u64);
+    let verified: u64 = shift_right_sticky_u64_verified(value, 12_u64);
+    assert(verified == baseline);
+}
+
+#[test]
+fn test_shr_sticky_u64_matches_baseline_low_bits_zero() {
+    // Bits below the shift are zero, so sticky == 0 even for a dynamic shift.
+    let value: u64 = 0xABCD_E000_u64;
+    let baseline: u64 = crate::utils::shift_right_sticky_u64(value, 12_u64);
+    let verified: u64 = shift_right_sticky_u64_verified(value, 12_u64);
+    assert(verified == baseline);
+}
+
+// ============================================================================
+// Tests -- adversarial (shr_sticky_u64)
+// ============================================================================
+//
+// Each adversarial path exercises one verifier clause. Sharing
+// `verify_shr_sticky_u64_relation` between production and tests means a
+// regression in the production verifier path would be caught here too.
+
+#[test(should_fail_with = "shift==0 quotient mismatch")]
+fn test_shr_sticky_u64_bad_quotient_zero_shift() {
+    // shift == 0: any (quotient != value) tampering is caught.
+    // Safety: adversarial path.
+    verify_shr_sticky_u64_relation(0xABCD_u64, 0_u64, 0_u64, 0_u64, 0_u1);
+}
+
+#[test(should_fail_with = "shift==0 sticky set")]
+fn test_shr_sticky_u64_bad_sticky_zero_shift() {
+    // shift == 0 with quotient correct but sticky set is rejected.
+    // Safety: adversarial path.
+    verify_shr_sticky_u64_relation(0xABCD_u64, 0_u64, 0xABCD_u64, 0_u64, 1_u1);
+}
+
+#[test(should_fail_with = "reconstruction failed")]
+fn test_shr_sticky_u64_bad_reconstruction() {
+    // value = 8, shift = 2: true (q, r, s) = (2, 0, 0). Feeding (3, 0, 0)
+    // breaks reconstruction: 3 * 4 + 0 == 12 != 8.
+    // Safety: adversarial path; we feed a deliberately-wrong quotient.
+    verify_shr_sticky_u64_relation(8_u64, 2_u64, 3_u64, 0_u64, 0_u1);
+}
+
+#[test(should_fail_with = "remainder above pow2")]
+fn test_shr_sticky_u64_bad_remainder_above_pow2() {
+    // value = 12, shift = 2, pow2 = 4: a malicious witness could try
+    // (q, r) = (2, 4). Reconstruction holds (2*4 + 4 == 12), but
+    // remainder == pow2 violates the bound. The verifier rejects.
+    // Safety: adversarial path.
+    verify_shr_sticky_u64_relation(12_u64, 2_u64, 2_u64, 4_u64, 1_u1);
+}
+
+#[test(should_fail_with = "sticky==0 but remainder nonzero")]
+fn test_shr_sticky_u64_bad_sticky_zero_with_remainder() {
+    // value = 11, shift = 2: true (q, r, s) = (2, 3, 1). Feeding sticky == 0
+    // is rejected by the (1 - sticky) * remainder == 0 clause.
+    // Safety: adversarial path.
+    verify_shr_sticky_u64_relation(11_u64, 2_u64, 2_u64, 3_u64, 0_u1);
+}
+
+#[test(should_fail_with = "sticky direction wrong")]
+fn test_shr_sticky_u64_bad_sticky_one_with_zero_remainder() {
+    // value = 8, shift = 2: true (q, r, s) = (2, 0, 0). Feeding sticky == 1
+    // is rejected by the remainder * remainder_inv == sticky clause:
+    // 0 * inv == 0 != 1.
+    // Safety: adversarial path.
+    verify_shr_sticky_u64_relation(8_u64, 2_u64, 2_u64, 0_u64, 1_u1);
+}
+
+#[test(should_fail_with = "shift>=64 quotient nonzero")]
+fn test_shr_sticky_u64_bad_quotient_shift_64() {
+    // shift == 64: quotient must be 0.
+    // Safety: adversarial path.
+    verify_shr_sticky_u64_relation(0_u64, 64_u64, 1_u64, 0_u64, 0_u1);
+}
+
+#[test(should_fail_with = "shift>=64 remainder mismatch")]
+fn test_shr_sticky_u64_bad_remainder_shift_64() {
+    // shift == 64: remainder must equal value.
+    // Safety: adversarial path.
+    verify_shr_sticky_u64_relation(0xABCD_u64, 64_u64, 0_u64, 0_u64, 1_u1);
+}
+
+#[test(should_fail_with = "shift>=64 sticky==0 but value nonzero")]
+fn test_shr_sticky_u64_bad_sticky_zero_shift_64() {
+    // shift == 64, value != 0, sticky claimed 0 -- rejected.
+    // Safety: adversarial path.
+    verify_shr_sticky_u64_relation(0xABCD_u64, 64_u64, 0_u64, 0xABCD_u64, 0_u1);
+}
+
+#[test]
+fn test_shr_sticky_u64_shift_far_above_64() {
+    // Drop-in compatibility with the baseline: very large shifts collapse to
+    // the "all bits shifted out" case. value != 0 so sticky == 1, encoded
+    // result == 0 | 1 == 1.
+    let result: u64 = shift_right_sticky_u64_verified(0xABCD_u64, 1000_u64);
+    assert(result == 1_u64);
+}

--- a/scripts/benchmark_gates.py
+++ b/scripts/benchmark_gates.py
@@ -113,7 +113,129 @@ BENCHMARKS = {
 # the headline `benchmarks` table.
 # ---------------------------------------------------------------------------
 
-PRIMITIVE_BENCHMARKS = {}
+PRIMITIVE_BENCHMARKS = {
+    # -- Isolated: the verifier on its own vs. the in-tree baseline copied
+    #    from `ieee754/src/utils.rs::shift_right_sticky_u64`. The shift is
+    #    a `pub u64` witness so constant-folding cannot collapse the
+    #    runtime branch.
+    "shr_sticky_u64_isolated_verified": {
+        "extra_use": "use ieee754::shift_right_sticky_u64_verified;",
+        "prelude": "",
+        "inputs": "value: pub u64, shift: pub u64",
+        "body": """
+    shift_right_sticky_u64_verified(value, shift)
+""",
+        "return_type": "pub u64",
+    },
+    "shr_sticky_u64_isolated_baseline": {
+        "extra_use": "",
+        "prelude": """
+fn shr_sticky_u64_baseline(value: u64, shift: u64) -> u64 {
+    if shift == 0 {
+        value
+    } else if shift >= 64 {
+        if value != 0 {
+            1
+        } else {
+            0
+        }
+    } else {
+        let mask = (1 << shift) - 1;
+        let shifted_out = value & mask;
+        let result = value >> shift;
+        if shifted_out != 0 {
+            result | 1
+        } else {
+            result
+        }
+    }
+}
+""",
+        "inputs": "value: pub u64, shift: pub u64",
+        "body": """
+    shr_sticky_u64_baseline(value, shift)
+""",
+        "return_type": "pub u64",
+    },
+    # -- Composed: emulate the denormal-mantissa shift step that float64
+    #    `mul`, `div`, and `sqrt` perform (a `shift_right_sticky_u64` driven
+    #    by a witness-dependent `denorm_shift`). The baseline copies the
+    #    in-tree code; the candidate replaces it with the verified primitive.
+    #    This is the measurement that actually answers
+    #    "should we swap call sites?".
+    "shr_sticky_u64_composed_verified": {
+        "extra_use": "use ieee754::shift_right_sticky_u64_verified;",
+        "prelude": """
+fn denorm_shift_verified(result_mant: u64, result_exp: i64) -> (u64, u64) {
+    let mut new_mant: u64 = result_mant;
+    let mut new_exp: u64 = 0;
+    if result_exp <= 0 {
+        let denorm_shift = (1 - result_exp) as u64;
+        if denorm_shift < 56 {
+            new_mant = shift_right_sticky_u64_verified(result_mant, denorm_shift);
+        } else {
+            new_mant = 0;
+        }
+    } else {
+        new_exp = result_exp as u64;
+    }
+    (new_mant, new_exp)
+}
+""",
+        "inputs": "result_mant: pub u64, result_exp: pub i64",
+        "body": """
+    let (m, e) = denorm_shift_verified(result_mant, result_exp);
+    m + e
+""",
+        "return_type": "pub u64",
+    },
+    "shr_sticky_u64_composed_baseline": {
+        "extra_use": "",
+        "prelude": """
+fn shr_sticky_u64_baseline(value: u64, shift: u64) -> u64 {
+    if shift == 0 {
+        value
+    } else if shift >= 64 {
+        if value != 0 {
+            1
+        } else {
+            0
+        }
+    } else {
+        let mask = (1 << shift) - 1;
+        let shifted_out = value & mask;
+        let result = value >> shift;
+        if shifted_out != 0 {
+            result | 1
+        } else {
+            result
+        }
+    }
+}
+fn denorm_shift_baseline(result_mant: u64, result_exp: i64) -> (u64, u64) {
+    let mut new_mant: u64 = result_mant;
+    let mut new_exp: u64 = 0;
+    if result_exp <= 0 {
+        let denorm_shift = (1 - result_exp) as u64;
+        if denorm_shift < 56 {
+            new_mant = shr_sticky_u64_baseline(result_mant, denorm_shift);
+        } else {
+            new_mant = 0;
+        }
+    } else {
+        new_exp = result_exp as u64;
+    }
+    (new_mant, new_exp)
+}
+""",
+        "inputs": "result_mant: pub u64, result_exp: pub i64",
+        "body": """
+    let (m, e) = denorm_shift_baseline(result_mant, result_exp);
+    m + e
+""",
+        "return_type": "pub u64",
+    },
+}
 
 
 def create_primitive_benchmark_project(tmpdir: Path, name: str, benchmark: dict) -> Path:

--- a/scripts/benchmark_gates.py
+++ b/scripts/benchmark_gates.py
@@ -157,12 +157,19 @@ fn shr_sticky_u64_baseline(value: u64, shift: u64) -> u64 {
 """,
         "return_type": "pub u64",
     },
-    # -- Composed: emulate the denormal-mantissa shift step that float64
-    #    `mul`, `div`, and `sqrt` perform (a `shift_right_sticky_u64` driven
-    #    by a witness-dependent `denorm_shift`). The baseline copies the
-    #    in-tree code; the candidate replaces it with the verified primitive.
-    #    This is the measurement that actually answers
-    #    "should we swap call sites?".
+    # -- Composed: emulate the denormal-mantissa shift step that
+    #    `float64/mul.nr` performs (a `shift_right_sticky_u64` driven by a
+    #    witness-dependent `denorm_shift = 1 - result_exp`, with a
+    #    `denorm_shift < 56` short-circuit copied verbatim from line 303 of
+    #    `ieee754/src/float64/mul.nr`). The baseline copies the in-tree code;
+    #    the candidate replaces the inner primitive with the verified one.
+    #    Other call sites use different short-circuit thresholds (27/28 in
+    #    float32, 57 in float64/{div,sqrt}); the verifier branches dynamically
+    #    on `shift` so the threshold does not affect the per-call cost shape,
+    #    but the surrounding straight-line code does, so this benchmark is the
+    #    apples-to-apples measurement only for the float64/mul.nr call site.
+    #    See `bench/SPIKES.md` for the verdict and §3.2 of the
+    #    `noir-optimisation` skill for the cost model.
     "shr_sticky_u64_composed_verified": {
         "extra_use": "use ieee754::shift_right_sticky_u64_verified;",
         "prelude": """
@@ -539,6 +546,27 @@ def print_comparison(old_results: dict, new_results: dict):
         total_pct = (total_diff / total_old * 100)
         print(f"{'TOTAL':<20} {total_old:>12} {total_new:>12} {total_diff:+d} ({total_pct:+.1f}%)")
     print("=" * 60)
+
+    # Also surface PRIMITIVE_BENCHMARKS deltas if either side has them.
+    old_primitives = old_results.get("primitive_benchmarks", {})
+    new_primitives = new_results.get("primitive_benchmarks", {})
+    if old_primitives or new_primitives:
+        print("\n" + "-" * 60)
+        print("PRIMITIVE BENCHMARKS")
+        print("-" * 60)
+        print(f"{'Variant':<40} {'Old W/A':>10} {'New W/A':>10}")
+        print("-" * 60)
+        for name in sorted(set(old_primitives.keys()) | set(new_primitives.keys())):
+            old_info = old_primitives.get(name, {})
+            new_info = new_primitives.get(name, {})
+            old_w = old_info.get("expression_width", "N/A")
+            old_a = old_info.get("acir_opcodes", "N/A")
+            new_w = new_info.get("expression_width", "N/A")
+            new_a = new_info.get("acir_opcodes", "N/A")
+            old_cell = f"{old_w}/{old_a}"
+            new_cell = f"{new_w}/{new_a}"
+            print(f"{name:<40} {old_cell:>10} {new_cell:>10}")
+        print("=" * 60)
 
 
 def print_summary(results: dict):


### PR DESCRIPTION
## Summary

- Add `shift_right_sticky_u64_verified` following the established `unconstrained + verified` template (`Spec.shr_sticky_u64` in `proofs/Ieee754/.../UnconstrainedOps.lean` already pinned). The Brillig hint witnesses `(quotient, remainder, sticky)`; the verifier asserts an algebraic relation -- Euclidean-division reconstruction over `Field` plus an existence-of-inverse pinning of the sticky direction.
- Measure isolated + composed against the in-tree `utils::shift_right_sticky_u64` baseline (composed regime mirrors the `denorm_shift < 56` block at `float64/mul.nr:303`).
- Verdict: **MIXED**. Verifier wins -5 Width / -7% in both regimes; loses +103 ACIR / +303% in both. The Width edge is too small to justify swapping call sites under the workspace rule "Width is what the prover pays for under Barretenberg" (PR #28 in `noir_XPath` swapped at -59% Width / +14x ACIR; this round is -7% / +4x). Primitive ships in the public API as a stable Lampe-extraction target; no call site swapped.

## Numbers

| Variant                              | Width | ACIR |
|--------------------------------------|------:|-----:|
| `shr_sticky_u64_isolated_baseline`   |    72 |   34 |
| `shr_sticky_u64_isolated_verified`   |    67 |  137 |
| `shr_sticky_u64_composed_baseline`   |   106 |   34 |
| `shr_sticky_u64_composed_verified`   |   101 |  137 |

Recorded in `bench/unconstrained_gate_counts.json` (against `nargo 1.0.0-beta.17`).

## Lean obligations

The four `sorry`-stubbed theorems already exist in `proofs/Ieee754/ZkpSparql/Ieee754/UnconstrainedOps.lean` (`shr_sticky_u64_unique`, `shr_sticky_u64_correct`, `Spec.shr_sticky_u64`, `Verified.shr_sticky_u64_relation`). No Lean change is required because the primitive ships -- the relation shape matches the `Spec.shr_sticky_u64` definition.

## Test plan

- [x] `nargo test --package ieee754` -- 36 tests pass (15 baseline + 21 new shr_sticky tests, of which 11 happy-path and 10 adversarial isolating each verifier clause).
- [x] `nargo test` (full workspace) -- 170 ieee754_unit_tests pass.
- [x] `python3 scripts/benchmark_gates.py` -- four `shr_sticky_u64_*` primitive entries reproduce, headline benchmarks unchanged.
- [x] Roborev (codex / gpt-5.5) review on every commit; final commit `cb3f887` returns "No issues found".

## Per-commit

| SHA | Subject | Roborev verdict |
|-----|---------|-----------------|
| `9c1f8cb` | feat(circuits): shift_right_sticky_u64 via unconstrained + verified pattern | Low: missing `shift>=64 sticky direction wrong` adversarial test |
| `0f497e5` | feat(circuits): add missing shift>=64 sticky-direction adversarial test | No issues found |
| `2b563e5` | bench: shr_sticky_u64 verifier vs in-tree baseline (isolated + composed) | Medium: composed comment too broad; Low: `print_comparison` skips primitives; Low: stale `git_commit` |
| `2c4f142` | bench: address roborev feedback on primitive comparison + comment | (closed by `deb9b32` + `cb3f887`) |
| `b8724f4` | docs(bench): record shr_sticky_u64 verified-relation MIXED verdict | Low: `git_commit` still stale |
| `deb9b32` | docs(bench): clarify JSON git_commit provenance, refresh ledger | Low: commit-count off-by-one in SPIKES note |
| `cb3f887` | docs(bench): fix commit-count off-by-one in SPIKES process note | No issues found |

## Out-of-scope follow-ups (documented in `bench/SPIKES.md`)

- **Constant-shift call site.** `float32/mul.nr:201` has `guard_shift = 46 - 26 = 20` known at compile time; the verifier's `1 << shift` would constant-fold and the relation might collapse to cheaper-than-baseline. Worth a focused `shr_sticky_u64_const20_*` benchmark.
- **`shr_sticky_u128_verified`.** The `float64/mul.nr` line 281 call uses the U128 variant; its in-circuit baseline is more complex and a verified variant could plausibly win where the u64 one only marginally does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)