### PR TITLE
spike(bench): shr_sticky_u64 constant-shift verifier (constant-shift case)

### DIFF
--- a/bench/SPIKES.md
+++ b/bench/SPIKES.md
@@ -277,6 +277,122 @@ to interpret a number against a future repo state, look at the
 
 ---
 
+## 2026-05-03 -- `shr_sticky_u64` constant-shift verifier (`shift = 20`)
+
+**Verdict:** **NO-GO.** Constant folding helps the in-tree baseline far
+more than the verifier; the verifier regresses on **both** Width
+(+2 / +13%) and ACIR (+94 / +553%) vs. the constant-shift baseline. No
+call sites swapped.
+
+**Branch:** `spike/shr-sticky-const-shift` (PR #<n>; benchmark + ledger
+entry only -- no source-level changes shipped).
+
+**Toolchain:** `nargo 1.0.0-beta.17` on macOS, against `origin/main` at
+`e4b9097` (post-PR #43 merge of the dynamic-shift verifier, post-PR #46
+docs sweep).
+
+### Motivation
+
+The dynamic-shift `shift_right_sticky_u64_verified` shipped in PR #43
+with a MIXED verdict (-7% Width / +303% ACIR -- see the entry above).
+The PR-43 agent flagged that `float32/mul.nr:201` calls
+`shift_right_sticky_u64(result_mant, guard_shift)` with
+`guard_shift = 46 - 26 = 20` known at compile time, and hypothesised
+that with a constant shift the verifier's `1 << shift` would
+constant-fold and the `if shift == 0 / >= 64 / else` cascade would
+collapse, possibly inverting the cost shape (and unlocking a targeted
+call-site swap).
+
+The user (Jesse) chose option A on
+`questions/shr-sticky-constant-shift-spike.md` -- spike the
+constant-shift case in isolation; defer the composed regime unless
+isolation shows a clear win.
+
+### Numbers
+
+Measured by `scripts/benchmark_gates.py`'s `PRIMITIVE_BENCHMARKS` --
+the new `shr_sticky_u64_const20_*` entries -- in the same run as the
+existing dynamic-shift `_isolated_*` and `_composed_*` rows, so the
+toolchain and harness are identical.
+
+| Variant                              | Width | ACIR |
+|--------------------------------------|------:|-----:|
+| `shr_sticky_u64_isolated_baseline`   |    72 |   34 |
+| `shr_sticky_u64_isolated_verified`   |    67 |  137 |
+| `shr_sticky_u64_const20_baseline`    |    15 |   17 |
+| `shr_sticky_u64_const20_verified`    |    17 |  111 |
+
+Constant folding cuts the **baseline** from 72 / 34 down to 15 / 17 --
+a 79% Width / 50% ACIR reduction. The branch cascade collapses
+entirely (only the `else` branch survives), `1 << 20` is a literal,
+`value >> 20` becomes a constant-divisor right shift, and the
+`mask = 0xFFFFF` becomes a literal AND. ACIR drops to 17.
+
+The **verifier** also benefits from constant folding -- Width 67 -> 17
+-- because the `if shift == 0 / >= 64 / else` cascade in
+`verify_shr_sticky_u64_relation` collapses to its third branch, and
+`pow2 = 1_u64 << shift` becomes the literal `0x100000`. But the
+relation-check ACIR opcodes are *unchanged* by constant folding:
+
+- `value_f == quotient_f * pow2_f + remainder_f` is one `AssertZero`
+  on Field witnesses (`quotient`, `remainder`) regardless of whether
+  `pow2` is a literal.
+- `remainder < pow2` is a u64 range check; the `pow2` constant just
+  sets the comparison constant.
+- `(1 - sticky) * remainder == 0` and
+  `remainder * remainder_inv == sticky` are unchanged -- they witness
+  unconstrained values (`sticky`, `remainder_inv`) and pin them via
+  Field equalities.
+
+So the verifier's ACIR floor (~110) is **structural in the witnessed
+relation**, not in the `pow2` compute, and constant folding cannot
+move it. Net: at `shift = 20` the verifier costs +2 Width and +94
+ACIR vs. the baseline.
+
+### Why the cost shape did *not* invert
+
+The PR #43 verdict (dynamic shift) was -7% Width / +303% ACIR. The
+hypothesis was that constant-folding `1 << shift` in the verifier
+would close the +303% ACIR gap.
+
+What actually happened: constant folding helped the baseline more
+than the verifier, because the baseline's *entire body* is in-circuit
+arithmetic (mask + shift + AND + OR), all of which fold under a
+literal shift; the verifier's body is mostly *witnessed* (`quotient`,
+`remainder`, `sticky`, `remainder_inv` are all unconstrained outputs)
+plus `AssertZero`s, which do not fold. The verifier's relation cost is
+a fixed tax that constant folding cannot amortise.
+
+### Implication for follow-on work
+
+- **Do not swap `float32/mul.nr:201`** to the verified primitive. The
+  in-tree `utils::shift_right_sticky_u64` is the right choice for any
+  compile-time-constant shift call site.
+- **Do not spike further constant-shift variants.** Other call sites
+  with literal shifts (e.g. `mul.nr:158` and `div.nr:164` use
+  `shift = 1`) will see the same structural verifier tax, just on a
+  smaller baseline. The baseline at `shift = 1` is even cheaper than
+  at `shift = 20`, so the gap widens, not narrows.
+- The verified primitive remains a stable public-API target for the
+  Lampe extraction round per the PR #43 entry; nothing here changes
+  that decision.
+- The `shr_sticky_u128` axis (float64/mul.nr:281) remains unexplored
+  -- the U128 baseline is more complex than the u64 one, so a U128
+  verified variant *might* win where u64 doesn't. Out of scope for
+  this round; flagged for a future spike.
+
+### Process
+
+- One source change (`scripts/benchmark_gates.py`): two new entries
+  `shr_sticky_u64_const20_baseline` and
+  `shr_sticky_u64_const20_verified` in `PRIMITIVE_BENCHMARKS`. No
+  changes to `ieee754/src/`. The merged `shift_right_sticky_u64_verified`
+  primitive is untouched.
+- Bench harness recorded in `gate_counts.json`.
+- Roborev (codex / gpt-5.5) per workspace rule.
+
+---
+
 ## Template
 
 ```

--- a/bench/SPIKES.md
+++ b/bench/SPIKES.md
@@ -284,7 +284,7 @@ more than the verifier; the verifier regresses on **both** Width
 (+2 / +13%) and ACIR (+94 / +553%) vs. the constant-shift baseline. No
 call sites swapped.
 
-**Branch:** `spike/shr-sticky-const-shift` (PR #<n>; benchmark + ledger
+**Branch:** `spike/shr-sticky-const-shift` (PR #47; benchmark + ledger
 entry only -- no source-level changes shipped).
 
 **Toolchain:** `nargo 1.0.0-beta.17` on macOS, against `origin/main` at
@@ -383,13 +383,15 @@ a fixed tax that constant folding cannot amortise.
 
 ### Process
 
-- One source change (`scripts/benchmark_gates.py`): two new entries
-  `shr_sticky_u64_const20_baseline` and
-  `shr_sticky_u64_const20_verified` in `PRIMITIVE_BENCHMARKS`. No
-  changes to `ieee754/src/`. The merged `shift_right_sticky_u64_verified`
-  primitive is untouched.
-- Bench harness recorded in `gate_counts.json`.
-- Roborev (codex / gpt-5.5) per workspace rule.
+- Spike-branch source change (`scripts/benchmark_gates.py`): two new
+  `PRIMITIVE_BENCHMARKS` entries `shr_sticky_u64_const20_baseline` and
+  `shr_sticky_u64_const20_verified`. No changes to `ieee754/src/`. The
+  merged `shift_right_sticky_u64_verified` primitive is untouched.
+- Bench run recorded in `gate_counts.json` on the spike branch.
+- Roborev (codex / gpt-5.5) "No issues found" on the bench-harness
+  commit; this ledger commit was reviewed in the same agent/model and
+  the low-severity wording / placeholder findings were addressed in a
+  follow-up commit.
 
 ---
 

--- a/gate_counts.json
+++ b/gate_counts.json
@@ -226,5 +226,69 @@
         "brillig_opcodes": 34
       }
     }
+  },
+  {
+    "timestamp": "2026-05-03T16:57:59.262936",
+    "git_commit": "e4b9097d",
+    "benchmarks": {
+      "add_float32": {
+        "expression_width": 610,
+        "acir_opcodes": 34
+      },
+      "mul_float32": {
+        "expression_width": 1053,
+        "acir_opcodes": 34
+      },
+      "sub_float32": {
+        "expression_width": 611,
+        "acir_opcodes": 34
+      },
+      "div_float32": {
+        "expression_width": 959,
+        "acir_opcodes": 34
+      },
+      "add_float64": {
+        "expression_width": 714,
+        "acir_opcodes": 34
+      },
+      "mul_float64": {
+        "expression_width": 1783,
+        "acir_opcodes": 34
+      },
+      "sub_float64": {
+        "expression_width": 715,
+        "acir_opcodes": 34
+      },
+      "div_float64": {
+        "expression_width": 4589,
+        "acir_opcodes": 34
+      }
+    },
+    "primitive_benchmarks": {
+      "shr_sticky_u64_isolated_verified": {
+        "expression_width": 67,
+        "acir_opcodes": 137
+      },
+      "shr_sticky_u64_isolated_baseline": {
+        "expression_width": 72,
+        "acir_opcodes": 34
+      },
+      "shr_sticky_u64_composed_verified": {
+        "expression_width": 101,
+        "acir_opcodes": 137
+      },
+      "shr_sticky_u64_composed_baseline": {
+        "expression_width": 106,
+        "acir_opcodes": 34
+      },
+      "shr_sticky_u64_const20_baseline": {
+        "expression_width": 15,
+        "acir_opcodes": 17
+      },
+      "shr_sticky_u64_const20_verified": {
+        "expression_width": 17,
+        "acir_opcodes": 111
+      }
+    }
   }
 ]

--- a/scripts/benchmark_gates.py
+++ b/scripts/benchmark_gates.py
@@ -242,6 +242,61 @@ fn denorm_shift_baseline(result_mant: u64, result_exp: i64) -> (u64, u64) {
 """,
         "return_type": "pub u64",
     },
+    # ------------------------------------------------------------------
+    # Constant-shift spike (DECIDED 2026-05-03 by Jesse).
+    #
+    # `float32/mul.nr:201` calls `shift_right_sticky_u64(result_mant,
+    # guard_shift)` where `guard_shift = 46 - 26 = 20` is known at
+    # compile time. Hypothesis: with a constant shift the verifier's
+    # `1 << shift` constant-folds and the `if shift == 0 / >= 64 / else`
+    # branches collapse, potentially inverting the cost shape vs. the
+    # PR #43 dynamic-shift verdict (-7% Width / +303% ACIR).
+    #
+    # `value` stays a `pub u64` witness so the operation does not
+    # collapse to a literal; only `shift` is a compile-time constant.
+    # See `bench/SPIKES.md` for the dynamic-shift entry this compares
+    # against.
+    # ------------------------------------------------------------------
+    "shr_sticky_u64_const20_baseline": {
+        "extra_use": "",
+        "prelude": """
+fn shr_sticky_u64_baseline_const20(value: u64) -> u64 {
+    let shift: u64 = 20;
+    if shift == 0 {
+        value
+    } else if shift >= 64 {
+        if value != 0 {
+            1
+        } else {
+            0
+        }
+    } else {
+        let mask = (1 << shift) - 1;
+        let shifted_out = value & mask;
+        let result = value >> shift;
+        if shifted_out != 0 {
+            result | 1
+        } else {
+            result
+        }
+    }
+}
+""",
+        "inputs": "value: pub u64",
+        "body": """
+    shr_sticky_u64_baseline_const20(value)
+""",
+        "return_type": "pub u64",
+    },
+    "shr_sticky_u64_const20_verified": {
+        "extra_use": "use ieee754::shift_right_sticky_u64_verified;",
+        "prelude": "",
+        "inputs": "value: pub u64",
+        "body": """
+    shift_right_sticky_u64_verified(value, 20_u64)
+""",
+        "return_type": "pub u64",
+    },
 }
 
 


### PR DESCRIPTION
## Summary

- Spikes `shr_sticky_u64_const20_*` benchmark variants per the question
  log (`questions/shr-sticky-constant-shift-spike.md`, decided 2026-05-03
  by Jesse). Tests whether a compile-time-constant shift (`shift = 20`,
  the `guard_shift = 46 - 26` case at `float32/mul.nr:201`) lets the
  verifier's `1 << shift` constant-fold and inverts the cost shape vs.
  the PR #43 dynamic-shift verdict (-7% Width / +303% ACIR).
- **Verdict: NO-GO.** The verifier regresses on **both** Width
  (+2 / +13%) and ACIR (+94 / +553%) vs. the constant-shift baseline at
  `shift = 20`. Constant folding helps the in-tree baseline more
  (72/34 -> 15/17) than the verifier (67/137 -> 17/111) because the
  baseline's mask + shift + AND + OR all fold under a literal shift,
  whereas the verifier's relation ACIR is structural in the witnessed
  `(quotient, remainder, sticky)` tuple and does not fold.
- No source-level changes to `ieee754/src/`; the merged dynamic-shift
  `shift_right_sticky_u64_verified` is untouched. No call sites swapped.
- Records the result in `bench/SPIKES.md` so future agents do not
  reattempt this axis. Flags `shr_sticky_u128` (float64/mul.nr:281) as
  the only remaining unexplored axis.

### Numbers (isolated)

| Variant                              | Width | ACIR |
|--------------------------------------|------:|-----:|
| `shr_sticky_u64_isolated_baseline`   |    72 |   34 |
| `shr_sticky_u64_isolated_verified`   |    67 |  137 |
| `shr_sticky_u64_const20_baseline`    |    15 |   17 |
| `shr_sticky_u64_const20_verified`    |    17 |  111 |

Composed regime not measured: per the spike instructions, isolated
showing the same regression regime as PR #43 is sufficient evidence to
conclude no-go.

## Test plan

- [x] `python3 scripts/benchmark_gates.py` compiles all
  `PRIMITIVE_BENCHMARKS` entries cleanly under `nargo 1.0.0-beta.17`.
- [x] Roborev (codex / gpt-5.5) "No issues found" on the bench-harness
  commit; SPIKES ledger commit's two low-severity findings addressed in
  the follow-up commit.
- [x] `git grep "shift_right_sticky_u64\|shr_sticky"` confirms no
  `ieee754/src/` files modified -- the merged primitive is untouched.

Auto-merge: squash + delete branch.