### PR TITLE
fix(tests): TestFloat corpus cache key, pin checkout, and pipe-error detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,37 +46,57 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev
 
       - name: Install Python deps
-        run: pip install -r scripts/requirements.txt
+        run: pip install -r scripts/requirements.txt pytest
 
       - name: Cross-check MPFR vs legacy reference oracle
         run: python3 scripts/test_reference.py
 
+      - name: Unit tests for TestFloat capture pipeline
+        # Roborev #448 medium #3 regression coverage: ensure
+        # ``run_testfloat_gen`` raises on real ``testfloat_gen``
+        # failures rather than silently accepting truncated captures.
+        run: python3 -m pytest scripts/test_run_testfloat_gen.py -v
+
       - name: Read TestFloat pins
         id: tf_pins
-        # The pins are the only inputs (besides --seed / --level /
-        # --max-per-function, all fixed below) that determine the corpus
-        # contents, so they form the natural cache key. We extract them
-        # by sourcing the regen script's pin block in a sub-shell so a
-        # future bump bumps the cache key automatically.
+        # The pins, plus the source-corpus dispatch table
+        # (``scripts/noir_ieee754_inputs/sources.py``), the capture
+        # driver (``scripts/noir_ieee754_inputs/testfloat.py``), and
+        # the regen shell script itself, determine which captures the
+        # corpus needs. We extract the pins from the regen script and
+        # additionally hash those source files into the cache key so a
+        # PR which adds an op / rounding mode (or adjusts the regen
+        # logic) invalidates the cache rather than silently reusing a
+        # stale corpus. Roborev #448 medium #1.
         run: |
           SF=$(grep -E '^SOFTFLOAT_PIN=' scripts/regenerate_testfloat_corpus.sh | sed -E 's/.*:-([0-9a-f]{40}).*/\1/')
           TF=$(grep -E '^TESTFLOAT_PIN=' scripts/regenerate_testfloat_corpus.sh | sed -E 's/.*:-([0-9a-f]{40}).*/\1/')
+          INPUT_FILES_HASH=$(sha256sum \
+            scripts/noir_ieee754_inputs/sources.py \
+            scripts/noir_ieee754_inputs/testfloat.py \
+            scripts/regenerate_testfloat_corpus.sh \
+            | sha256sum | cut -c1-16)
           echo "softfloat=$SF" >> "$GITHUB_OUTPUT"
           echo "testfloat=$TF" >> "$GITHUB_OUTPUT"
-          echo "Extracted pins: softfloat=$SF testfloat=$TF"
+          echo "input_files=$INPUT_FILES_HASH" >> "$GITHUB_OUTPUT"
+          echo "Extracted pins: softfloat=$SF testfloat=$TF input_files=$INPUT_FILES_HASH"
 
       - name: Cache TestFloat corpus
         # Cache the generated ``.testfloat_cache/`` directory keyed on
-        # (softfloat-3 commit, testfloat-3 commit, max-per-function cap,
-        # seed, level). When any input changes, the manifest check inside
-        # ``regenerate_testfloat_corpus.sh`` invalidates the on-disk
-        # cache and the script regenerates from upstream. When inputs are
-        # stable, this saves ~150 s (clone + build + 70 captures).
+        # (softfloat-3 commit, testfloat-3 commit, capture-driver hash,
+        # max-per-function cap, seed, level). The ``input_files`` hash
+        # component covers ``noir_ieee754_inputs/sources.py`` +
+        # ``testfloat.py`` + ``regenerate_testfloat_corpus.sh`` so a PR
+        # that adds / removes an operation / rounding mode (or adjusts
+        # the regen logic) gets a fresh cache slot. The
+        # manifest-check inside the regen script remains as a
+        # second-line defence. When inputs are stable, the cache hit
+        # saves ~150 s (clone + build + 70 captures).
         uses: actions/cache@v4
         id: testfloat_cache
         with:
           path: .testfloat_cache
-          key: testfloat-corpus-sf=${{ steps.tf_pins.outputs.softfloat }}-tf=${{ steps.tf_pins.outputs.testfloat }}-cap=2000-seed=1-level=1
+          key: testfloat-corpus-sf=${{ steps.tf_pins.outputs.softfloat }}-tf=${{ steps.tf_pins.outputs.testfloat }}-inp=${{ steps.tf_pins.outputs.input_files }}-cap=2000-seed=1-level=1
 
       - name: Build Berkeley TestFloat corpus
         # Builds Berkeley SoftFloat-3 + TestFloat-3 from upstream sources

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ node_modules/
 
 # OS files
 .DS_Store
+
+# Local Python venvs used for running scripts/test_*.py
+.venv/
+.pytest_cache/

--- a/scripts/noir_ieee754_inputs/testfloat.py
+++ b/scripts/noir_ieee754_inputs/testfloat.py
@@ -355,9 +355,13 @@ class TestFloatGenError(RuntimeError):
 # Exit codes that we treat as "testfloat_gen was killed by SIGPIPE
 # because the consumer closed the pipe early". Python's
 # ``Popen.wait()`` returns the negative signal number on POSIX (so
-# ``-13`` for SIGPIPE), but some shells / runners report ``141`` /
-# ``143`` instead -- accept all conventions.
-_SIGPIPE_RCS: frozenset[int] = frozenset({-13, 141, 143})
+# ``-13`` for SIGPIPE); some shells / runners surface SIGPIPE as
+# ``128 + 13 = 141``. We deliberately do NOT include ``143`` here:
+# ``143 = 128 + 15`` is the convention for SIGTERM, and a
+# SIGTERM-killed ``testfloat_gen`` is a real failure (typically a
+# wrapper or CI hand-off bug) that we want to surface as an error
+# rather than silently accept (Roborev #448 follow-up).
+_SIGPIPE_RCS: frozenset[int] = frozenset({-13, 141})
 
 
 def run_testfloat_gen(

--- a/scripts/noir_ieee754_inputs/testfloat.py
+++ b/scripts/noir_ieee754_inputs/testfloat.py
@@ -343,6 +343,23 @@ def parse_testfloat_file(
 # Driver (used at corpus-generation time, e.g. in CI).
 
 
+class TestFloatGenError(RuntimeError):
+    """Raised when ``testfloat_gen`` itself failed (non-SIGPIPE non-zero exit)."""
+
+    # Tell pytest this is not a test class (the ``Test*`` prefix triggers
+    # collection by default and otherwise fights ``RuntimeError``'s
+    # ``__init__`` signature).
+    __test__ = False
+
+
+# Exit codes that we treat as "testfloat_gen was killed by SIGPIPE
+# because the consumer closed the pipe early". Python's
+# ``Popen.wait()`` returns the negative signal number on POSIX (so
+# ``-13`` for SIGPIPE), but some shells / runners report ``141`` /
+# ``143`` instead -- accept all conventions.
+_SIGPIPE_RCS: frozenset[int] = frozenset({-13, 141, 143})
+
+
 def run_testfloat_gen(
     binary: str | os.PathLike[str],
     *,
@@ -357,6 +374,15 @@ def run_testfloat_gen(
 
     ``output_path`` defaults to ``<function>_<rounding>.tfgen`` in the
     current directory. Returns the path to the captured file.
+
+    Roborev #448 medium #3 hardening: when ``max_tests`` is set we read
+    N lines and then close the pipe, expecting ``testfloat_gen`` to
+    receive SIGPIPE. We assert that the process exited because of
+    SIGPIPE rather than a genuine error -- the previous implementation
+    did ``cmd | head`` via ``shell=True`` and only saw ``head``'s
+    return code, so a ``testfloat_gen`` segfault would silently produce
+    a truncated capture. On any non-SIGPIPE non-zero exit we delete the
+    partial output file and raise :class:`TestFloatGenError`.
     """
     if output_path is None:
         output_path = Path(f"{function.name}_{rounding.name.lower()}.tfgen")
@@ -375,15 +401,34 @@ def run_testfloat_gen(
             subprocess.run(args, stdout=out_fh, check=True)
         else:
             # ``testfloat_gen`` won't accept ``-n`` below the level-N
-            # minimum, so we let it run to completion and slice afterwards.
-            # For the operations whose level-1 corpus exceeds a reasonable
-            # CI window (mulAdd: 6.1M cases) we want to truncate the file.
-            with subprocess.Popen(args, stdout=subprocess.PIPE, text=True) as proc:
+            # minimum, so we let it stream and read the first ``max_tests``
+            # lines. For the operations whose level-1 corpus exceeds a
+            # reasonable CI window (mulAdd: 6.1M cases) we cap.
+            proc = subprocess.Popen(args, stdout=subprocess.PIPE, text=True)
+            try:
                 assert proc.stdout is not None
                 for line_number, line in enumerate(proc.stdout, 1):
                     out_fh.write(line)
                     if line_number >= max_tests:
-                        proc.terminate()
                         break
+            finally:
+                # Closing our end first lets ``testfloat_gen`` notice
+                # the consumer is gone (SIGPIPE on its next write) and
+                # exit cleanly rather than continuing to fill its
+                # ~6.1M-line buffer.
+                if proc.stdout is not None:
+                    proc.stdout.close()
+                rc = proc.wait()
+            if rc != 0 and rc not in _SIGPIPE_RCS:
+                # Wipe the partial capture so a re-run regenerates it
+                # rather than treating the truncated file as cached.
+                try:
+                    output_path.unlink()
+                except FileNotFoundError:
+                    pass
+                raise TestFloatGenError(
+                    f"testfloat_gen failed (rc={rc}) for "
+                    f"{function.name}/{rounding.name}: args={args}"
+                )
 
     return output_path

--- a/scripts/regenerate_testfloat_corpus.sh
+++ b/scripts/regenerate_testfloat_corpus.sh
@@ -64,20 +64,43 @@ if [[ -z "${TESTFLOAT_GEN:-}" ]]; then
     SOFTFLOAT_DIR="${SOFTFLOAT_DIR:-$BUILD_DIR/berkeley-softfloat-3}"
     TESTFLOAT_DIR="${TESTFLOAT_DIR:-$BUILD_DIR/berkeley-testfloat-3}"
 
-    # Clone-and-checkout-pin pattern: clone with full history (so the
-    # pinned commit is reachable) then check out the exact revision. We
-    # avoid ``--depth=1`` here because that would only give us the tip of
-    # ``master``; the pin would be unreachable without unshallowing.
-    if [[ ! -d "$SOFTFLOAT_DIR" ]]; then
-        echo "Cloning Berkeley SoftFloat-3 to $SOFTFLOAT_DIR (pin=$SOFTFLOAT_PIN)..."
-        git clone https://github.com/ucb-bar/berkeley-softfloat-3 "$SOFTFLOAT_DIR"
-        (cd "$SOFTFLOAT_DIR" && git checkout --detach "$SOFTFLOAT_PIN")
-    fi
-    if [[ ! -d "$TESTFLOAT_DIR" ]]; then
-        echo "Cloning Berkeley TestFloat-3 to $TESTFLOAT_DIR (pin=$TESTFLOAT_PIN)..."
-        git clone https://github.com/ucb-bar/berkeley-testfloat-3 "$TESTFLOAT_DIR"
-        (cd "$TESTFLOAT_DIR" && git checkout --detach "$TESTFLOAT_PIN")
-    fi
+    # Clone-and-checkout-pin pattern. Two failure modes the original
+    # implementation missed (Roborev #448 medium #2):
+    #
+    # 1. Pre-existing source directories (a prior CI run that re-used
+    #    the workspace, a mounted dev cache, ``SOFTFLOAT_DIR`` /
+    #    ``TESTFLOAT_DIR`` overrides) only got the checkout on initial
+    #    clone. After a ``SOFTFLOAT_PIN`` / ``TESTFLOAT_PIN`` bump
+    #    those directories silently kept the old pin, so re-runs
+    #    built from the *old* upstream source with the *new* pin
+    #    recorded in ``manifest.txt`` -- a soundness hole for the
+    #    corpus the manifest is meant to attest.
+    # 2. ``git clone`` without ``--depth=1`` is wasteful (~80 MB per
+    #    repo) when we only ever check out one commit.
+    #
+    # Remediation: always run ``git fetch <PIN> + git checkout <PIN>``
+    # regardless of whether the directory pre-existed. We use a
+    # filter-blobless clone, then a depth-1 fetch of the pinned SHA
+    # (GitHub allows reachable-SHA fetches via
+    # ``uploadpack.allowReachableSHA1InWant``); the working tree stays
+    # small while we can still check out the exact pin.
+    _ensure_pin () {
+        local dir="$1" url="$2" pin="$3"
+        if [[ ! -d "$dir/.git" ]]; then
+            echo "Cloning $url to $dir..."
+            git clone --filter=blob:none --no-checkout "$url" "$dir"
+        fi
+        (
+            cd "$dir"
+            # Always re-fetch the pinned SHA so a bump between runs
+            # invalidates a stale checkout.
+            echo "Fetching pin $pin in $dir..."
+            git fetch --depth=1 origin "$pin"
+            git checkout --detach --force "$pin"
+        )
+    }
+    _ensure_pin "$SOFTFLOAT_DIR" "https://github.com/ucb-bar/berkeley-softfloat-3" "$SOFTFLOAT_PIN"
+    _ensure_pin "$TESTFLOAT_DIR" "https://github.com/ucb-bar/berkeley-testfloat-3" "$TESTFLOAT_PIN"
 
     # Pick a build template based on host platform. The Linux-x86_64-GCC
     # template is the closest match for both Linux/GCC and macOS/clang;
@@ -172,8 +195,6 @@ fi
 
 PYTHONPATH="$SCRIPT_DIR" python3 - <<EOF
 from pathlib import Path
-import os
-import subprocess
 import sys
 
 sys.path.insert(0, "$SCRIPT_DIR")
@@ -181,7 +202,8 @@ sys.path.insert(0, "$SCRIPT_DIR")
 from noir_ieee754_inputs.sources import OPERATION_SOURCES, SourceCorpus
 from noir_ieee754_inputs.testfloat import (
     SUPPORTED_FUNCTIONS,
-    ROUNDING_FLAGS,
+    TestFloatGenError,
+    run_testfloat_gen,
 )
 
 cache_dir = Path("$CACHE_DIR")
@@ -222,29 +244,29 @@ for fn, rnd in pairs:
     if out.exists() and out.stat().st_size > 0:
         print(f"  cached {out.name}")
         continue
-    args = [
-        binary,
-        "-seed", str(seed),
-        "-level", str(level),
-        ROUNDING_FLAGS[rnd],
-        fn.name,
-    ]
-    if max_per_function is not None:
-        # Truncate at source. ``testfloat_gen`` for ``mulAdd`` at level 1
-        # emits ~6.1M cases per rounding mode; the downstream loader caps
-        # per-function output anyway, so writing the full stream wastes
-        # significant CI minutes and disk I/O.
-        cmd = "{} | head -n {}".format(
-            " ".join(args),
-            int(max_per_function),
-        )
-        print(f"  + {cmd} > {out.name}")
-        with open(out, "w") as fh:
-            subprocess.run(cmd, shell=True, stdout=fh, check=True)
+    cap = max_per_function
+    if cap is not None:
+        # ``testfloat_gen`` for ``mulAdd`` at level 1 emits ~6.1M cases
+        # per rounding mode; the downstream loader caps per-function
+        # output anyway, so writing the full stream wastes CI minutes
+        # and disk. ``run_testfloat_gen`` handles SIGPIPE-on-close
+        # cleanly and raises ``TestFloatGenError`` on any genuine
+        # ``testfloat_gen`` failure (Roborev #448 medium #3).
+        print(f"  + testfloat_gen ... {fn.name} | first {cap} > {out.name}")
     else:
-        print(f"  + {' '.join(args)} > {out.name}")
-        with open(out, "w") as fh:
-            subprocess.run(args, stdout=fh, check=True)
+        print(f"  + testfloat_gen ... {fn.name} > {out.name}")
+    try:
+        run_testfloat_gen(
+            binary,
+            function=fn,
+            rounding=rnd,
+            seed=seed,
+            level=level,
+            max_tests=cap,
+            output_path=out,
+        )
+    except TestFloatGenError as exc:
+        sys.exit(str(exc))
 
 print("Done.")
 EOF

--- a/scripts/test_run_testfloat_gen.py
+++ b/scripts/test_run_testfloat_gen.py
@@ -1,0 +1,153 @@
+"""Regression tests for ``run_testfloat_gen`` capture-then-truncate semantics.
+
+Roborev #448 medium #3: the previous regen pipeline did
+``testfloat_gen | head`` via ``shell=True`` which silently swallowed
+``testfloat_gen`` failures (only ``head``'s exit status reached the
+caller). These tests use a stub ``testfloat_gen`` shell script to
+exercise three scenarios:
+
+1. The stub emits more lines than ``max_tests``, so ``run_testfloat_gen``
+   closes the pipe early and the stub dies of SIGPIPE -- this must
+   *not* raise. The truncated capture file contains exactly
+   ``max_tests`` lines.
+2. The stub exits non-zero before reaching ``max_tests`` -- this must
+   raise ``TestFloatGenError`` and delete the partial capture.
+3. The stub exits zero with fewer than ``max_tests`` lines -- this is
+   accepted and the capture file holds exactly the lines emitted.
+
+Run via ``python -m pytest scripts/test_run_testfloat_gen.py``.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+from noir_ieee754_inputs.fptest import RoundingMode  # noqa: E402
+from noir_ieee754_inputs.testfloat import (  # noqa: E402
+    SUPPORTED_FUNCTIONS,
+    TestFloatGenError,
+    run_testfloat_gen,
+)
+
+
+def _make_stub(tmp_path: Path, body: str) -> Path:
+    """Materialise a shell stub that mimics testfloat_gen output."""
+    stub = tmp_path / "stub_gen"
+    stub.write_text("#!/bin/bash\n" + body)
+    stub.chmod(stub.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return stub
+
+
+@pytest.fixture
+def f64_add_function():
+    """Pick any supported function; the stub doesn't actually parse args."""
+    for fn in SUPPORTED_FUNCTIONS.values():
+        if fn.name == "f64_add":
+            return fn
+    raise AssertionError("f64_add not registered in SUPPORTED_FUNCTIONS")
+
+
+def test_max_tests_truncates_long_stream_without_raising(tmp_path, f64_add_function):
+    """Stub emits 1000 lines; we cap at 5; the stub dies of SIGPIPE on
+    the next write. Must *not* raise; capture file holds exactly 5
+    lines. This is the canonical happy-path for the bounded regen."""
+    stub = _make_stub(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            for i in $(seq 1 1000); do
+                printf 'line %d\\n' "$i"
+            done
+            """
+        ),
+    )
+    out = tmp_path / "f64_add_rne.tfgen"
+    result = run_testfloat_gen(
+        stub,
+        function=f64_add_function,
+        rounding=RoundingMode.NEAREST_EVEN,
+        max_tests=5,
+        output_path=out,
+    )
+    assert result == out
+    assert out.exists()
+    lines = out.read_text().splitlines()
+    assert lines == [f"line {i}" for i in range(1, 6)]
+
+
+def test_failing_stub_raises_and_deletes_partial_capture(tmp_path, f64_add_function):
+    """Stub exits 1 after 2 lines (well below max_tests). Roborev #448
+    medium #3 regression: the previous shell-pipe pipeline reported
+    only ``head``'s exit, so a real ``testfloat_gen`` segfault would
+    look successful. ``run_testfloat_gen`` must raise here."""
+    stub = _make_stub(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            printf 'line 1\\n'
+            printf 'line 2\\n'
+            exit 7
+            """
+        ),
+    )
+    out = tmp_path / "f64_add_rne.tfgen"
+    with pytest.raises(TestFloatGenError) as exc:
+        run_testfloat_gen(
+            stub,
+            function=f64_add_function,
+            rounding=RoundingMode.NEAREST_EVEN,
+            max_tests=100,
+            output_path=out,
+        )
+    assert "rc=7" in str(exc.value)
+    assert not out.exists(), "partial capture must be wiped"
+
+
+def test_short_stream_succeeds_when_under_max_tests(tmp_path, f64_add_function):
+    """Stub emits 3 lines and exits 0; max_tests=100. We accept the
+    short stream rather than insisting on exactly max_tests."""
+    stub = _make_stub(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            printf 'line 1\\nline 2\\nline 3\\n'
+            """
+        ),
+    )
+    out = tmp_path / "f64_add_rne.tfgen"
+    run_testfloat_gen(
+        stub,
+        function=f64_add_function,
+        rounding=RoundingMode.NEAREST_EVEN,
+        max_tests=100,
+        output_path=out,
+    )
+    assert out.read_text() == "line 1\nline 2\nline 3\n"
+
+
+def test_unbounded_capture_paths_still_propagate_failures(tmp_path, f64_add_function):
+    """When ``max_tests`` is None we use ``subprocess.run(..., check=True)``;
+    a failing stub must still raise (CalledProcessError, not TestFloatGenError --
+    this is the unmodified path)."""
+    import subprocess
+    stub = _make_stub(
+        tmp_path,
+        "exit 9\n",
+    )
+    out = tmp_path / "f64_add_rne.tfgen"
+    with pytest.raises(subprocess.CalledProcessError):
+        run_testfloat_gen(
+            stub,
+            function=f64_add_function,
+            rounding=RoundingMode.NEAREST_EVEN,
+            max_tests=None,
+            output_path=out,
+        )

--- a/scripts/test_run_testfloat_gen.py
+++ b/scripts/test_run_testfloat_gen.py
@@ -151,3 +151,30 @@ def test_unbounded_capture_paths_still_propagate_failures(tmp_path, f64_add_func
             max_tests=None,
             output_path=out,
         )
+
+
+def test_sigterm_exit_code_is_not_treated_as_sigpipe(tmp_path, f64_add_function):
+    """Roborev follow-up: ``143`` is ``128 + SIGTERM``, not SIGPIPE.
+    A stub that exits ``143`` (e.g. a wrapper killed by SIGTERM) must
+    raise rather than be silently accepted as a successful early
+    truncation."""
+    stub = _make_stub(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            printf 'line 1\\n'
+            exit 143
+            """
+        ),
+    )
+    out = tmp_path / "f64_add_rne.tfgen"
+    with pytest.raises(TestFloatGenError) as exc:
+        run_testfloat_gen(
+            stub,
+            function=f64_add_function,
+            rounding=RoundingMode.NEAREST_EVEN,
+            max_tests=100,
+            output_path=out,
+        )
+    assert "rc=143" in str(exc.value)
+    assert not out.exists(), "partial capture must be wiped"


### PR DESCRIPTION
## Summary

Addresses Roborev #448's three medium findings on the TestFloat regen pipeline:

| # | Finding | Fix |
|---|---|---|
| 1 | CI cache key omits inputs that determine which captures are required (`ci.yml:71`). | Hash `noir_ieee754_inputs/sources.py`, `noir_ieee754_inputs/testfloat.py`, and `regenerate_testfloat_corpus.sh` into the cache key. |
| 2 | Pinned commits only checked out on initial clone (`regenerate_testfloat_corpus.sh:73`); existing build dirs drift after a pin bump. | New `_ensure_pin` helper always runs `git fetch --depth=1 origin <PIN>` + `git checkout --detach --force <PIN>`. |
| 3 | `testfloat_gen | head` via `shell=True` swallowed `testfloat_gen` failures. | Replace inline shell pipe with `noir_ieee754_inputs.testfloat.run_testfloat_gen`, hardened to raise `TestFloatGenError` on non-SIGPIPE non-zero exit and delete the partial capture file. |

## Soundness rationale

The TestFloat corpus underwrites the IEEE 754 soundness claim. A stale cache, a drifted pin, or a silently-truncated capture each weaken that claim without surfacing as a CI failure. All three fixes turn previously-silent regressions into loud ones.

## Test plan

- [x] New `scripts/test_run_testfloat_gen.py` (4 tests, all passing locally):
  - happy-path: long stream truncated at `max_tests` does NOT raise
  - regression: stub exits 1 before `max_tests` raises `TestFloatGenError` and deletes the partial file (the canonical regression case for finding 3)
  - short stream: less than `max_tests` lines, exit 0, accepted
  - unbounded path: stub exits non-zero -> `CalledProcessError`
- [x] Wired `pytest scripts/test_run_testfloat_gen.py` into `.github/workflows/ci.yml`.
- [x] `bash -n scripts/regenerate_testfloat_corpus.sh`: clean.
- [x] `python -c "import ast; ast.parse(...)"` on the heredoc Python: clean.
- [x] `python scripts/test_reference.py`: 8302/8302 passing (no regression on existing reference oracle).

## Coordination

- Independent of #143 (dependabots) and #148 / #149 (sparql_noir / proofs/).
- Touches `ci.yml` cache-key step + `regenerate_testfloat_corpus.sh` + `noir_ieee754_inputs/testfloat.py`. No collision with the active `ci/require-copilot-review` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)