### PR TITLE
proofs: literate add_f32_equivalence in add.nr (lampe-literate bootstrap)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ noir/lib/*/lampe/
 # module and the cached lake build. Regenerated from the literate Noir
 # directive lines each time `lampe-literate build` runs; never edited
 # by hand.
+# lampe-literate scratch dir (per-source). Contains the Lampe-extracted
+# Lean, the spliced proof module, and the cached lake build. Regenerated
+# from the literate Noir comment blocks each time `lampe-literate build`
+# runs; never edited by hand.
 **/.lampe-literate/
 
 # Node.js / semantic-release

--- a/ieee754/proofs/add_f32_equivalence.lean
+++ b/ieee754/proofs/add_f32_equivalence.lean
@@ -1,0 +1,134 @@
+/-! ## Inlined-RNE divergence: definitionally equal -/
+
+/-- The optimised path's inlined round-to-nearest-even computation
+is the body of `shouldRoundUp` for `mode = 0`. -/
+theorem shouldRoundUp_inline_eq
+    (guardBits : BitVec 64) (resultMant : BitVec 64)
+    (resultSign : BitVec 1) :
+    shouldRoundUp guardBits resultMant resultSign 0
+      = (decide (guardBits.toNat > 4)
+          || (decide (guardBits = 4) && decide (resultMant &&& 1 = 1))) := by
+  -- Both sides unfold to the same boolean expression.
+  unfold shouldRoundUp
+  simp [modeNearestEven]
+
+/-! ## Diverging-parameter equalities -/
+
+/-- The optimised `clz` parameter equals the reference's: `clzBinary
+= clzLoop` pointwise. Round-5 `Subterms.clz_eq`, taken symmetrically
+and lifted to a function-level equality. -/
+private theorem clz_param_eq : clzBinary = clzLoop := by
+  funext v; exact (clz_eq v).symm
+
+/-- The optimised `rneDecision` parameter (inline-RNE wrapper) equals
+the reference's (`shouldRoundUp`). For `mode = modeNearestEven` both
+sides reduce to the same boolean expression by
+`shouldRoundUp_inline_eq`; for `mode ≠ modeNearestEven` the wrapper
+falls through to `shouldRoundUp` directly. -/
+private theorem rne_param_eq :
+    (fun (gb : BitVec 64) (rm : BitVec 64) (rs : BitVec 1) (m : BitVec 8) =>
+      if m = 0 then
+        decide (gb.toNat > 4) ||
+          (decide (gb = 4) && decide (rm &&& 1 = 1))
+      else
+        shouldRoundUp gb rm rs m) = shouldRoundUp := by
+  funext gb rm rs m
+  by_cases hmode : m = 0
+  · subst hmode
+    rw [if_pos rfl]
+    exact (shouldRoundUp_inline_eq gb rm rs).symm
+  · rw [if_neg hmode]
+
+/-! ## Alignment-triple equality
+
+The two alignment functions produce the same `(mantAShift,
+mantBShift, resultExpInit)` triple for every input. The round-6
+3-way trichotomy on `expA.toNat`/`expB.toNat` reduces each branch to
+a `BitVec 64` equality discharged by `shr_sticky_eq` (unequal
+exponents) or `shrStickyHelper_zero` (equal exponents).
+
+Crucially the trichotomy is *contained* in this lemma — it does not
+rewrite under the long `addF32Skeleton` body. The lemma's goal is a
+ground equality of two triples in `BitVec 64`; `rfl` (after the
+`simp only` rewrite chain has folded the alignment) holds without
+depending on the heartbeat-fragile definitional equality at the
+skeleton level. -/
+
+private theorem align_eq (a b : Float32Bits) :
+    alignF32Optimised a b = alignF32Reference a b := by
+  unfold alignF32Optimised alignF32Reference
+  -- Short-hand for the effective exponents.
+  set expA : BitVec 64 := effectiveExp a with hExpA
+  set expB : BitVec 64 := effectiveExp b with hExpB
+  rcases lt_trichotomy expA.toNat expB.toNat with hlt | heq | hgt
+  · -- expA < expB: optimised takes the `expB > expA` branch
+    -- (`mantA := shrStickyInline mantA (expB - expA)`); reference
+    -- selects `shrStickyHelper mantAAligned (expB - expA)`.
+    have hngeA : ¬ expA.toNat ≥ expB.toNat := by omega
+    have hngtA : ¬ expA.toNat > expB.toNat := by omega
+    have hgtB : expB.toNat > expA.toNat := hlt
+    have hshift_ne : (expB - expA).toNat ≠ 0 := by
+      rw [BitVec.toNat_sub]
+      have hb_lt : expB.toNat < 18446744073709551616 := BitVec.isLt _
+      have ha_lt : expA.toNat < 18446744073709551616 := BitVec.isLt _
+      omega
+    simp only [Id.run, hngeA, hngtA, hgtB, if_true, if_false,
+               ge_iff_le, Nat.not_le_of_lt, shr_sticky_eq _ _ hshift_ne]
+    rfl
+  · -- expA = expB: both alignments leave the mantissas un-shifted
+    -- (optimised: neither `if`-branch fires; reference:
+    -- `shrStickyHelper _ 0 = id` via `shrStickyHelper_zero`).
+    have hsub : expA - expB = 0 := by
+      apply BitVec.eq_of_toNat_eq
+      rw [BitVec.toNat_sub, heq]
+      have hbound : expB.toNat ≤ 18446744073709551616 :=
+        Nat.le_of_lt (BitVec.isLt _)
+      change _ = (0 : BitVec 64).toNat
+      simp; omega
+    have hsub' : expB - expA = 0 := by
+      apply BitVec.eq_of_toNat_eq
+      rw [BitVec.toNat_sub, ← heq]
+      have hbound : expA.toNat ≤ 18446744073709551616 :=
+        Nat.le_of_lt (BitVec.isLt _)
+      change _ = (0 : BitVec 64).toNat
+      simp; omega
+    have hge : expA.toNat ≥ expB.toNat := Nat.le_of_eq heq.symm
+    have hngtA : ¬ expA.toNat > expB.toNat := by omega
+    have hngtB : ¬ expB.toNat > expA.toNat := by omega
+    have hexp_eq : expA = expB := by
+      apply BitVec.eq_of_toNat_eq; exact heq
+    simp only [Id.run, hngtA, hngtB, hge, ge_iff_le, hsub, hsub',
+               shrStickyHelper_zero, if_true, if_false]
+    rfl
+  · -- expA > expB: optimised takes the `expA > expB` branch
+    -- (`mantB := shrStickyInline mantB (expA - expB)`); reference
+    -- selects `shrStickyHelper mantBAligned (expA - expB)`.
+    have hge : expA.toNat ≥ expB.toNat := Nat.le_of_lt hgt
+    have hngtB : ¬ expB.toNat > expA.toNat := by omega
+    have hshift_ne : (expA - expB).toNat ≠ 0 := by
+      rw [BitVec.toNat_sub]
+      have hb_lt : expB.toNat < 18446744073709551616 := BitVec.isLt _
+      have ha_lt : expA.toNat < 18446744073709551616 := BitVec.isLt _
+      omega
+    simp only [Id.run, hgt, hngtB, hge, ge_iff_le, if_true, if_false,
+               shr_sticky_eq _ _ hshift_ne]
+    rfl
+
+/-! ## Main theorem
+
+The optimised f32 add is bit-identical to the literal-IEEE-754
+reference f32 add, for every input and every rounding mode.
+
+The proof unfolds both wrappers, rewrites the alignment triple
+(folding the optimised `Id.run`-style alignment into the reference
+form via `align_eq`), and rewrites the two diverging-subterm
+parameters (`clz_param_eq`, `rne_param_eq`); `rfl` then sees both
+sides as the same `addF32Skeleton`-application. -/
+
+theorem add_f32_equivalence
+    (a b : Float32Bits) (mode : BitVec 8) :
+    addF32Optimised a b mode = addF32Reference a b mode := by
+  unfold addF32Optimised addF32Reference
+  rw [align_eq a b, clz_param_eq, rne_param_eq]
+
+end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/add_f32_preamble.lean
+++ b/ieee754/proofs/add_f32_preamble.lean
@@ -1,0 +1,7 @@
+import ZkpSparql.Ieee754.Equivalence.Models
+import ZkpSparql.Ieee754.Equivalence.Subterms
+
+namespace ZkpSparql.Ieee754.Equivalence
+
+open ZkpSparql.Ieee754.Equivalence.Models
+open ZkpSparql.Ieee754.Equivalence.Subterms

--- a/ieee754/src/float32/add.nr
+++ b/ieee754/src/float32/add.nr
@@ -20,160 +20,18 @@ use crate::utils::{assert_valid_rounding_mode, directed_overflow_saturates_to_in
 // a footgun that masks calling-side bugs.
 //
 // ----------------------------------------------------------------------------
-// Lean equivalence proof — see `circuits/lampe-literate` for the build tool
-// that extracts the comment blocks below and runs `lake build` against the
+// Lean equivalence proof. See `circuits/lampe-literate` for the build tool
+// that resolves the LAMPE-LITERATE directives below, splices the referenced
+// proof file into a generated Lean module, and runs `lake build` against the
 // workspace's shared `Models.lean` / `Subterms.lean` / `Spec.lean`. Generated
-// `.lean` files land in a gitignored scratch dir; only this Noir source is
-// version-controlled. Method: skeleton-and-specialisations (round 7;
+// `.lean` files land in a gitignored scratch dir; only this Noir source plus
+// the standalone `.lean` proof files are version-controlled. Method:
+// skeleton-and-specialisations (round 7;
 // `proofs/Ieee754/equivalence-spike-2026-05-04.md`).
 // ----------------------------------------------------------------------------
 //
-// ===== LAMPE-LITERATE BEGIN preamble =====
-// import ZkpSparql.Ieee754.Equivalence.Models
-// import ZkpSparql.Ieee754.Equivalence.Subterms
-//
-// namespace ZkpSparql.Ieee754.Equivalence
-//
-// open ZkpSparql.Ieee754.Equivalence.Models
-// open ZkpSparql.Ieee754.Equivalence.Subterms
-// ===== LAMPE-LITERATE END =====
-//
-// ===== LAMPE-LITERATE BEGIN proof fn=add_float32_with_rounding name=add_f32_equivalence =====
-// /-! ## Inlined-RNE divergence: definitionally equal -/
-//
-// /-- The optimised path's inlined round-to-nearest-even computation
-// is the body of `shouldRoundUp` for `mode = 0`. -/
-// theorem shouldRoundUp_inline_eq
-//     (guardBits : BitVec 64) (resultMant : BitVec 64)
-//     (resultSign : BitVec 1) :
-//     shouldRoundUp guardBits resultMant resultSign 0
-//       = (decide (guardBits.toNat > 4)
-//           || (decide (guardBits = 4) && decide (resultMant &&& 1 = 1))) := by
-//   -- Both sides unfold to the same boolean expression.
-//   unfold shouldRoundUp
-//   simp [modeNearestEven]
-//
-// /-! ## Diverging-parameter equalities -/
-//
-// /-- The optimised `clz` parameter equals the reference's: `clzBinary
-// = clzLoop` pointwise. Round-5 `Subterms.clz_eq`, taken symmetrically
-// and lifted to a function-level equality. -/
-// private theorem clz_param_eq : clzBinary = clzLoop := by
-//   funext v; exact (clz_eq v).symm
-//
-// /-- The optimised `rneDecision` parameter (inline-RNE wrapper) equals
-// the reference's (`shouldRoundUp`). For `mode = modeNearestEven` both
-// sides reduce to the same boolean expression by
-// `shouldRoundUp_inline_eq`; for `mode ≠ modeNearestEven` the wrapper
-// falls through to `shouldRoundUp` directly. -/
-// private theorem rne_param_eq :
-//     (fun (gb : BitVec 64) (rm : BitVec 64) (rs : BitVec 1) (m : BitVec 8) =>
-//       if m = 0 then
-//         decide (gb.toNat > 4) ||
-//           (decide (gb = 4) && decide (rm &&& 1 = 1))
-//       else
-//         shouldRoundUp gb rm rs m) = shouldRoundUp := by
-//   funext gb rm rs m
-//   by_cases hmode : m = 0
-//   · subst hmode
-//     rw [if_pos rfl]
-//     exact (shouldRoundUp_inline_eq gb rm rs).symm
-//   · rw [if_neg hmode]
-//
-// /-! ## Alignment-triple equality
-//
-// The two alignment functions produce the same `(mantAShift,
-// mantBShift, resultExpInit)` triple for every input. The round-6
-// 3-way trichotomy on `expA.toNat`/`expB.toNat` reduces each branch to
-// a `BitVec 64` equality discharged by `shr_sticky_eq` (unequal
-// exponents) or `shrStickyHelper_zero` (equal exponents).
-//
-// Crucially the trichotomy is *contained* in this lemma — it does not
-// rewrite under the long `addF32Skeleton` body. The lemma's goal is a
-// ground equality of two triples in `BitVec 64`; `rfl` (after the
-// `simp only` rewrite chain has folded the alignment) holds without
-// depending on the heartbeat-fragile definitional equality at the
-// skeleton level. -/
-//
-// private theorem align_eq (a b : Float32Bits) :
-//     alignF32Optimised a b = alignF32Reference a b := by
-//   unfold alignF32Optimised alignF32Reference
-//   -- Short-hand for the effective exponents.
-//   set expA : BitVec 64 := effectiveExp a with hExpA
-//   set expB : BitVec 64 := effectiveExp b with hExpB
-//   rcases lt_trichotomy expA.toNat expB.toNat with hlt | heq | hgt
-//   · -- expA < expB: optimised takes the `expB > expA` branch
-//     -- (`mantA := shrStickyInline mantA (expB - expA)`); reference
-//     -- selects `shrStickyHelper mantAAligned (expB - expA)`.
-//     have hngeA : ¬ expA.toNat ≥ expB.toNat := by omega
-//     have hngtA : ¬ expA.toNat > expB.toNat := by omega
-//     have hgtB : expB.toNat > expA.toNat := hlt
-//     have hshift_ne : (expB - expA).toNat ≠ 0 := by
-//       rw [BitVec.toNat_sub]
-//       have hb_lt : expB.toNat < 18446744073709551616 := BitVec.isLt _
-//       have ha_lt : expA.toNat < 18446744073709551616 := BitVec.isLt _
-//       omega
-//     simp only [Id.run, hngeA, hngtA, hgtB, if_true, if_false,
-//                ge_iff_le, Nat.not_le_of_lt, shr_sticky_eq _ _ hshift_ne]
-//     rfl
-//   · -- expA = expB: both alignments leave the mantissas un-shifted
-//     -- (optimised: neither `if`-branch fires; reference:
-//     -- `shrStickyHelper _ 0 = id` via `shrStickyHelper_zero`).
-//     have hsub : expA - expB = 0 := by
-//       apply BitVec.eq_of_toNat_eq
-//       rw [BitVec.toNat_sub, heq]
-//       have hbound : expB.toNat ≤ 18446744073709551616 :=
-//         Nat.le_of_lt (BitVec.isLt _)
-//       change _ = (0 : BitVec 64).toNat
-//       simp; omega
-//     have hsub' : expB - expA = 0 := by
-//       apply BitVec.eq_of_toNat_eq
-//       rw [BitVec.toNat_sub, ← heq]
-//       have hbound : expA.toNat ≤ 18446744073709551616 :=
-//         Nat.le_of_lt (BitVec.isLt _)
-//       change _ = (0 : BitVec 64).toNat
-//       simp; omega
-//     have hge : expA.toNat ≥ expB.toNat := Nat.le_of_eq heq.symm
-//     have hngtA : ¬ expA.toNat > expB.toNat := by omega
-//     have hngtB : ¬ expB.toNat > expA.toNat := by omega
-//     have hexp_eq : expA = expB := by
-//       apply BitVec.eq_of_toNat_eq; exact heq
-//     simp only [Id.run, hngtA, hngtB, hge, ge_iff_le, hsub, hsub',
-//                shrStickyHelper_zero, if_true, if_false]
-//     rfl
-//   · -- expA > expB: optimised takes the `expA > expB` branch
-//     -- (`mantB := shrStickyInline mantB (expA - expB)`); reference
-//     -- selects `shrStickyHelper mantBAligned (expA - expB)`.
-//     have hge : expA.toNat ≥ expB.toNat := Nat.le_of_lt hgt
-//     have hngtB : ¬ expB.toNat > expA.toNat := by omega
-//     have hshift_ne : (expA - expB).toNat ≠ 0 := by
-//       rw [BitVec.toNat_sub]
-//       have hb_lt : expB.toNat < 18446744073709551616 := BitVec.isLt _
-//       have ha_lt : expA.toNat < 18446744073709551616 := BitVec.isLt _
-//       omega
-//     simp only [Id.run, hgt, hngtB, hge, ge_iff_le, if_true, if_false,
-//                shr_sticky_eq _ _ hshift_ne]
-//     rfl
-//
-// /-! ## Main theorem
-//
-// The optimised f32 add is bit-identical to the literal-IEEE-754
-// reference f32 add, for every input and every rounding mode.
-//
-// The proof unfolds both wrappers, rewrites the alignment triple
-// (folding the optimised `Id.run`-style alignment into the reference
-// form via `align_eq`), and rewrites the two diverging-subterm
-// parameters (`clz_param_eq`, `rne_param_eq`); `rfl` then sees both
-// sides as the same `addF32Skeleton`-application. -/
-//
-// theorem add_f32_equivalence
-//     (a b : Float32Bits) (mode : BitVec 8) :
-//     addF32Optimised a b mode = addF32Reference a b mode := by
-//   unfold addF32Optimised addF32Reference
-//   rw [align_eq a b, clz_param_eq, rne_param_eq]
-//
-// end ZkpSparql.Ieee754.Equivalence
-// ===== LAMPE-LITERATE END =====
+// LAMPE-LITERATE preamble: ../../proofs/add_f32_preamble.lean
+// LAMPE-LITERATE proof:    ../../proofs/add_f32_equivalence.lean fn=add_float32_with_rounding name=add_f32_equivalence
 pub fn add_float32_with_rounding(
     a: IEEE754Float32,
     b: IEEE754Float32,

--- a/ieee754/src/float32/add.nr
+++ b/ieee754/src/float32/add.nr
@@ -22,7 +22,7 @@ use crate::utils::{assert_valid_rounding_mode, directed_overflow_saturates_to_in
 // ----------------------------------------------------------------------------
 // Lean equivalence proof. See `circuits/lampe-literate` for the build tool
 // that resolves the LAMPE-LITERATE directives below, splices the referenced
-// proof file into a generated Lean module, and runs `lake build` against the
+// preamble + proof files into a generated Lean module, and runs `lake build` against the
 // workspace's shared `Models.lean` / `Subterms.lean` / `Spec.lean`. Generated
 // `.lean` files land in a gitignored scratch dir; only this Noir source plus
 // the standalone `.lean` proof files are version-controlled. Method:

--- a/ieee754/src/float32/add.nr
+++ b/ieee754/src/float32/add.nr
@@ -18,6 +18,162 @@ use crate::utils::{assert_valid_rounding_mode, directed_overflow_saturates_to_in
 // `crate::types` (i.e. `0..=4`). Any other value triggers an assertion
 // failure -- silently treating an unknown mode as round-to-nearest-even is
 // a footgun that masks calling-side bugs.
+//
+// ----------------------------------------------------------------------------
+// Lean equivalence proof — see `circuits/lampe-literate` for the build tool
+// that extracts the comment blocks below and runs `lake build` against the
+// workspace's shared `Models.lean` / `Subterms.lean` / `Spec.lean`. Generated
+// `.lean` files land in a gitignored scratch dir; only this Noir source is
+// version-controlled. Method: skeleton-and-specialisations (round 7;
+// `proofs/Ieee754/equivalence-spike-2026-05-04.md`).
+// ----------------------------------------------------------------------------
+//
+// ===== LAMPE-LITERATE BEGIN preamble =====
+// import ZkpSparql.Ieee754.Equivalence.Models
+// import ZkpSparql.Ieee754.Equivalence.Subterms
+//
+// namespace ZkpSparql.Ieee754.Equivalence
+//
+// open ZkpSparql.Ieee754.Equivalence.Models
+// open ZkpSparql.Ieee754.Equivalence.Subterms
+// ===== LAMPE-LITERATE END =====
+//
+// ===== LAMPE-LITERATE BEGIN proof fn=add_float32_with_rounding name=add_f32_equivalence =====
+// /-! ## Inlined-RNE divergence: definitionally equal -/
+//
+// /-- The optimised path's inlined round-to-nearest-even computation
+// is the body of `shouldRoundUp` for `mode = 0`. -/
+// theorem shouldRoundUp_inline_eq
+//     (guardBits : BitVec 64) (resultMant : BitVec 64)
+//     (resultSign : BitVec 1) :
+//     shouldRoundUp guardBits resultMant resultSign 0
+//       = (decide (guardBits.toNat > 4)
+//           || (decide (guardBits = 4) && decide (resultMant &&& 1 = 1))) := by
+//   -- Both sides unfold to the same boolean expression.
+//   unfold shouldRoundUp
+//   simp [modeNearestEven]
+//
+// /-! ## Diverging-parameter equalities -/
+//
+// /-- The optimised `clz` parameter equals the reference's: `clzBinary
+// = clzLoop` pointwise. Round-5 `Subterms.clz_eq`, taken symmetrically
+// and lifted to a function-level equality. -/
+// private theorem clz_param_eq : clzBinary = clzLoop := by
+//   funext v; exact (clz_eq v).symm
+//
+// /-- The optimised `rneDecision` parameter (inline-RNE wrapper) equals
+// the reference's (`shouldRoundUp`). For `mode = modeNearestEven` both
+// sides reduce to the same boolean expression by
+// `shouldRoundUp_inline_eq`; for `mode ≠ modeNearestEven` the wrapper
+// falls through to `shouldRoundUp` directly. -/
+// private theorem rne_param_eq :
+//     (fun (gb : BitVec 64) (rm : BitVec 64) (rs : BitVec 1) (m : BitVec 8) =>
+//       if m = 0 then
+//         decide (gb.toNat > 4) ||
+//           (decide (gb = 4) && decide (rm &&& 1 = 1))
+//       else
+//         shouldRoundUp gb rm rs m) = shouldRoundUp := by
+//   funext gb rm rs m
+//   by_cases hmode : m = 0
+//   · subst hmode
+//     rw [if_pos rfl]
+//     exact (shouldRoundUp_inline_eq gb rm rs).symm
+//   · rw [if_neg hmode]
+//
+// /-! ## Alignment-triple equality
+//
+// The two alignment functions produce the same `(mantAShift,
+// mantBShift, resultExpInit)` triple for every input. The round-6
+// 3-way trichotomy on `expA.toNat`/`expB.toNat` reduces each branch to
+// a `BitVec 64` equality discharged by `shr_sticky_eq` (unequal
+// exponents) or `shrStickyHelper_zero` (equal exponents).
+//
+// Crucially the trichotomy is *contained* in this lemma — it does not
+// rewrite under the long `addF32Skeleton` body. The lemma's goal is a
+// ground equality of two triples in `BitVec 64`; `rfl` (after the
+// `simp only` rewrite chain has folded the alignment) holds without
+// depending on the heartbeat-fragile definitional equality at the
+// skeleton level. -/
+//
+// private theorem align_eq (a b : Float32Bits) :
+//     alignF32Optimised a b = alignF32Reference a b := by
+//   unfold alignF32Optimised alignF32Reference
+//   -- Short-hand for the effective exponents.
+//   set expA : BitVec 64 := effectiveExp a with hExpA
+//   set expB : BitVec 64 := effectiveExp b with hExpB
+//   rcases lt_trichotomy expA.toNat expB.toNat with hlt | heq | hgt
+//   · -- expA < expB: optimised takes the `expB > expA` branch
+//     -- (`mantA := shrStickyInline mantA (expB - expA)`); reference
+//     -- selects `shrStickyHelper mantAAligned (expB - expA)`.
+//     have hngeA : ¬ expA.toNat ≥ expB.toNat := by omega
+//     have hngtA : ¬ expA.toNat > expB.toNat := by omega
+//     have hgtB : expB.toNat > expA.toNat := hlt
+//     have hshift_ne : (expB - expA).toNat ≠ 0 := by
+//       rw [BitVec.toNat_sub]
+//       have hb_lt : expB.toNat < 18446744073709551616 := BitVec.isLt _
+//       have ha_lt : expA.toNat < 18446744073709551616 := BitVec.isLt _
+//       omega
+//     simp only [Id.run, hngeA, hngtA, hgtB, if_true, if_false,
+//                ge_iff_le, Nat.not_le_of_lt, shr_sticky_eq _ _ hshift_ne]
+//     rfl
+//   · -- expA = expB: both alignments leave the mantissas un-shifted
+//     -- (optimised: neither `if`-branch fires; reference:
+//     -- `shrStickyHelper _ 0 = id` via `shrStickyHelper_zero`).
+//     have hsub : expA - expB = 0 := by
+//       apply BitVec.eq_of_toNat_eq
+//       rw [BitVec.toNat_sub, heq]
+//       have hbound : expB.toNat ≤ 18446744073709551616 :=
+//         Nat.le_of_lt (BitVec.isLt _)
+//       change _ = (0 : BitVec 64).toNat
+//       simp; omega
+//     have hsub' : expB - expA = 0 := by
+//       apply BitVec.eq_of_toNat_eq
+//       rw [BitVec.toNat_sub, ← heq]
+//       have hbound : expA.toNat ≤ 18446744073709551616 :=
+//         Nat.le_of_lt (BitVec.isLt _)
+//       change _ = (0 : BitVec 64).toNat
+//       simp; omega
+//     have hge : expA.toNat ≥ expB.toNat := Nat.le_of_eq heq.symm
+//     have hngtA : ¬ expA.toNat > expB.toNat := by omega
+//     have hngtB : ¬ expB.toNat > expA.toNat := by omega
+//     have hexp_eq : expA = expB := by
+//       apply BitVec.eq_of_toNat_eq; exact heq
+//     simp only [Id.run, hngtA, hngtB, hge, ge_iff_le, hsub, hsub',
+//                shrStickyHelper_zero, if_true, if_false]
+//     rfl
+//   · -- expA > expB: optimised takes the `expA > expB` branch
+//     -- (`mantB := shrStickyInline mantB (expA - expB)`); reference
+//     -- selects `shrStickyHelper mantBAligned (expA - expB)`.
+//     have hge : expA.toNat ≥ expB.toNat := Nat.le_of_lt hgt
+//     have hngtB : ¬ expB.toNat > expA.toNat := by omega
+//     have hshift_ne : (expA - expB).toNat ≠ 0 := by
+//       rw [BitVec.toNat_sub]
+//       have hb_lt : expB.toNat < 18446744073709551616 := BitVec.isLt _
+//       have ha_lt : expA.toNat < 18446744073709551616 := BitVec.isLt _
+//       omega
+//     simp only [Id.run, hgt, hngtB, hge, ge_iff_le, if_true, if_false,
+//                shr_sticky_eq _ _ hshift_ne]
+//     rfl
+//
+// /-! ## Main theorem
+//
+// The optimised f32 add is bit-identical to the literal-IEEE-754
+// reference f32 add, for every input and every rounding mode.
+//
+// The proof unfolds both wrappers, rewrites the alignment triple
+// (folding the optimised `Id.run`-style alignment into the reference
+// form via `align_eq`), and rewrites the two diverging-subterm
+// parameters (`clz_param_eq`, `rne_param_eq`); `rfl` then sees both
+// sides as the same `addF32Skeleton`-application. -/
+//
+// theorem add_f32_equivalence
+//     (a b : Float32Bits) (mode : BitVec 8) :
+//     addF32Optimised a b mode = addF32Reference a b mode := by
+//   unfold addF32Optimised addF32Reference
+//   rw [align_eq a b, clz_param_eq, rne_param_eq]
+//
+// end ZkpSparql.Ieee754.Equivalence
+// ===== LAMPE-LITERATE END =====
 pub fn add_float32_with_rounding(
     a: IEEE754Float32,
     b: IEEE754Float32,


### PR DESCRIPTION
## Summary

- Pivot the literate `add_float32_with_rounding` proof to **option-3 directive form**: two ASCII `// LAMPE-LITERATE preamble:` / `// LAMPE-LITERATE proof:` lines beside the optimised function pointing at standalone `.lean` files in `ieee754/proofs/`.
- Carries the round-6 `add_f32_equivalence` theorem (preamble + proof) in `ieee754/proofs/add_f32_*.lean` (Unicode-permitted; `nargo` never reads them).
- Extends `.gitignore` with `**/.lampe-literate/` so the per-source scratch tree the build tool generates stays out of VCS.

## Why option-3, not embedded comments

The earlier revision of this PR embedded the Lean preamble + proof inside `// ===== LAMPE-LITERATE BEGIN ... =====` comment blocks. CI was red on `error: Non-ASCII character in comment` across 1.0.0-beta.14/15/16. Empirical test 2026-05-05 ruled out the embedded form: Noir's lexer rejects non-ASCII in **both** `//` and `/* */` comments. Lean tactics use Unicode (`→`, `≤`, `∀`, `≡`, `⊢`, ...) heavily, so external `.lean` files are the only viable layout.

Spec: workspace `decisions/lampe-literate-tool.md` (revised 2026-05-05).
Tooling: jeswr/lampe-literate#1 ships the directive-grammar parser that consumes these lines.

## Verification

- `nargo check` on `ieee754` passes (the original Non-ASCII errors clear; unrelated `unsafe`-block warnings remain).
- `lampe-literate check ieee754/src/float32/add.nr` from the workspace root parses both directives, resolves the relative paths, and materialises the spliced Lean module with Unicode round-tripped verbatim.
- `lake build` of the spliced project is exercised by the workspace's lampe-literate.toml flow (workspace#63); not run by this PR's local CI.

## Test plan

- [x] `nargo check` on ieee754 — no Non-ASCII errors
- [x] `lampe-literate check` on `add.nr` — both directives resolve, Generated.lean contains the full proof
- [ ] CI unit-tests (1.0.0-beta.14/15/16) green — fixed by this commit
- [ ] `lake build` end-to-end via the workspace lampe-literate.toml — verified separately on workspace#63