### PR TITLE
proofs(f32 helpers): trivial-tier equivalences for classifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,12 @@ noir/lib/reference_tests/Prover.toml
 # Never edited by hand. Re-run `lampe` after touching the underlying .nr.
 noir/lib/*/lampe/
 
+# lampe-literate scratch dir (per-source). Contains the spliced proof
+# module and the cached lake build. Regenerated from the literate Noir
+# directive lines each time `lampe-literate build` runs; never edited
+# by hand.
+**/.lampe-literate/
+
 # Node.js / semantic-release
 node_modules/
 # package-lock.json

--- a/ieee754/proofs/helpers_f32_equivalence.lean
+++ b/ieee754/proofs/helpers_f32_equivalence.lean
@@ -1,0 +1,19 @@
+/-! # Equivalence theorems: f32 classifiers
+
+For each helper, the optimised hand-port equals the canonical
+classifier in `Equivalence.Models`. Both sides are the same `Bool`
+expression after unfolding, so `rfl` closes each goal. -/
+
+theorem float32_is_nan_equivalence (x : Float32Bits) :
+    float32IsNanOptimised x = isNaN x := rfl
+
+theorem float32_is_infinity_equivalence (x : Float32Bits) :
+    float32IsInfinityOptimised x = isInf x := rfl
+
+theorem float32_is_zero_equivalence (x : Float32Bits) :
+    float32IsZeroOptimised x = isZero x := rfl
+
+theorem float32_is_denormal_equivalence (x : Float32Bits) :
+    float32IsDenormalOptimised x = isDenormal x := rfl
+
+end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/helpers_f32_preamble.lean
+++ b/ieee754/proofs/helpers_f32_preamble.lean
@@ -1,0 +1,41 @@
+import ZkpSparql.Ieee754.Equivalence.Models
+
+namespace ZkpSparql.Ieee754.Equivalence
+
+open ZkpSparql.Ieee754.Equivalence.Models
+
+/-! # Trivial-tier helpers: bit-pattern classifiers (f32)
+
+The Noir helpers `float32_is_nan`, `float32_is_infinity`,
+`float32_is_zero`, and `float32_is_denormal` (in
+`ieee754/src/float32/helpers.nr`) are pure bit-pattern checks: each
+ANDs two equality / inequality tests on the `exponent` and
+`mantissa` fields of `IEEE754Float32`. The Lean models in
+`Equivalence.Models` (`isNaN`, `isInf`, `isZero`, `isDenormal`)
+mirror this exactly. The equivalence theorems below state that the
+literal Noir-mirrored "Optimised" function equals the canonical
+classifier in `Models`; both sides reduce to the same `Bool`
+expression by definitional unfolding. -/
+
+/-! ## Optimised models: literal hand-ports of the Noir bodies -/
+
+/-- Literal hand-port of `float32_is_nan` from
+`ieee754/src/float32/helpers.nr`: `(exponent == 0xFF) & (mantissa != 0)`. -/
+def float32IsNanOptimised (x : Float32Bits) : Bool :=
+  decide (x.exponent = expMax) && decide (x.mantissa ≠ 0)
+
+/-- Literal hand-port of `float32_is_infinity`:
+`(exponent == 0xFF) & (mantissa == 0)`. -/
+def float32IsInfinityOptimised (x : Float32Bits) : Bool :=
+  decide (x.exponent = expMax) && decide (x.mantissa = 0)
+
+/-- Literal hand-port of `float32_is_zero`:
+`(exponent == 0) & (mantissa == 0)`. The sign bit is ignored, so
+both `+0` and `-0` map to `true`. -/
+def float32IsZeroOptimised (x : Float32Bits) : Bool :=
+  decide (x.exponent = 0) && decide (x.mantissa = 0)
+
+/-- Literal hand-port of `float32_is_denormal`:
+`(exponent == 0) & (mantissa != 0)`. -/
+def float32IsDenormalOptimised (x : Float32Bits) : Bool :=
+  decide (x.exponent = 0) && decide (x.mantissa ≠ 0)

--- a/ieee754/src/float32/helpers.nr
+++ b/ieee754/src/float32/helpers.nr
@@ -5,6 +5,9 @@
 use crate::types::{FLOAT32_EXPONENT_MAX, IEEE754Float32};
 
 // Check if Float32 is NaN (exponent = 255, mantissa != 0)
+//
+// LAMPE-LITERATE preamble: ../../proofs/helpers_f32_preamble.lean
+// LAMPE-LITERATE proof:    ../../proofs/helpers_f32_equivalence.lean fn=float32_is_nan name=float32_is_nan_equivalence
 pub fn float32_is_nan(x: IEEE754Float32) -> bool {
     (x.exponent == FLOAT32_EXPONENT_MAX) & (x.mantissa != 0)
 }


### PR DESCRIPTION
## Summary

Lands four trivial-tier (Tier 1) Lean equivalence theorems for the f32 bit-pattern classifiers in `ieee754/src/float32/helpers.nr`:

* `float32_is_nan_equivalence`
* `float32_is_infinity_equivalence`
* `float32_is_zero_equivalence`
* `float32_is_denormal_equivalence`

Each Noir helper hand-ports to a literal `(exponent EQ X) && (mantissa OP Y)` boolean in `helpers_f32_preamble.lean`; the matching theorem in `helpers_f32_equivalence.lean` reduces to `rfl` against the canonical `Equivalence.Models.{isNaN,isInf,isZero,isDenormal}` classifier.

`is_zero` correctly ignores the sign bit; the spec form uses only `exponent` + `mantissa`, so both `+0` and `-0` map to `true`.

## Methodology

Wave 13 / Tier 1 (trivial). Same lampe-literate plumbing as PR #60: directive lines beside `float32_is_nan` point at standalone `.lean` files in `ieee754/proofs/`. Other classifiers in the same file are covered by the single proof body, splice-concatenated by `lampe-literate`.

## Verification

- [x] `nargo check` on `ieee754` — clean (no new errors)
- [x] `lampe-literate check ieee754/src/float32/helpers.nr` — directives parse, splice resolves the imported `Models.lean` symbols, generated `.lean` is well-formed
- [ ] `lake build` end-to-end — offloaded to CI (mathlib cold-cache cost)

`.gitignore` extends with `**/.lampe-literate/` so the per-source scratch tree stays out of VCS (mirrors the add_f32 bootstrap PR #60).

## Test plan

- [ ] CI green on this branch
- [ ] Roborev review addressed
- [ ] After merge: workspace `proofs/Ieee754/PROOF-GAP-MATRIX.md` (if added) marks the four cells closed