### PR TITLE
proofs(f64 helpers): trivial-tier equivalences for classifiers

### DIFF
--- a/ieee754/proofs/helpers_f64_equivalence.lean
+++ b/ieee754/proofs/helpers_f64_equivalence.lean
@@ -1,0 +1,19 @@
+/-! # Equivalence theorems: f64 classifiers
+
+For each helper, the optimised hand-port equals the canonical
+classifier in `Equivalence.ModelsF64`. Both sides are the same
+`Bool` expression after unfolding, so `rfl` closes each goal. -/
+
+theorem float64_is_nan_equivalence (x : Float64Bits) :
+    float64IsNanOptimised x = isNaN64 x := rfl
+
+theorem float64_is_infinity_equivalence (x : Float64Bits) :
+    float64IsInfinityOptimised x = isInf64 x := rfl
+
+theorem float64_is_zero_equivalence (x : Float64Bits) :
+    float64IsZeroOptimised x = isZero64 x := rfl
+
+theorem float64_is_denormal_equivalence (x : Float64Bits) :
+    float64IsDenormalOptimised x = isDenormal64 x := rfl
+
+end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/helpers_f64_preamble.lean
+++ b/ieee754/proofs/helpers_f64_preamble.lean
@@ -1,0 +1,38 @@
+import ZkpSparql.Ieee754.Equivalence.ModelsF64
+
+namespace ZkpSparql.Ieee754.Equivalence
+
+open ZkpSparql.Ieee754.Equivalence.ModelsF64
+
+/-! # Trivial-tier helpers: bit-pattern classifiers (f64)
+
+The Noir helpers `float64_is_nan`, `float64_is_infinity`,
+`float64_is_zero`, and `float64_is_denormal` (in
+`ieee754/src/float64/helpers.nr`) are pure bit-pattern checks on
+the `exponent` and `mantissa` fields of `IEEE754Float64`. The Lean
+classifiers in `Equivalence.ModelsF64` (`isNaN64`, `isInf64`,
+`isZero64`, `isDenormal64`) mirror this exactly. Each equivalence
+theorem reduces to `rfl`. -/
+
+/-! ## Optimised models: literal hand-ports of the Noir bodies -/
+
+/-- Literal hand-port of `float64_is_nan` from
+`ieee754/src/float64/helpers.nr`: `(exponent == 2047) & (mantissa != 0)`. -/
+def float64IsNanOptimised (x : Float64Bits) : Bool :=
+  decide (x.exponent = expMax64) && decide (x.mantissa ≠ 0)
+
+/-- Literal hand-port of `float64_is_infinity`:
+`(exponent == 2047) & (mantissa == 0)`. -/
+def float64IsInfinityOptimised (x : Float64Bits) : Bool :=
+  decide (x.exponent = expMax64) && decide (x.mantissa = 0)
+
+/-- Literal hand-port of `float64_is_zero`:
+`(exponent == 0) & (mantissa == 0)`. The sign bit is ignored, so
+both `+0` and `-0` map to `true`. -/
+def float64IsZeroOptimised (x : Float64Bits) : Bool :=
+  decide (x.exponent = 0) && decide (x.mantissa = 0)
+
+/-- Literal hand-port of `float64_is_denormal`:
+`(exponent == 0) & (mantissa != 0)`. -/
+def float64IsDenormalOptimised (x : Float64Bits) : Bool :=
+  decide (x.exponent = 0) && decide (x.mantissa ≠ 0)

--- a/ieee754/src/float64/helpers.nr
+++ b/ieee754/src/float64/helpers.nr
@@ -5,6 +5,9 @@
 use crate::types::{FLOAT64_EXPONENT_MAX, IEEE754Float64};
 
 // Check if Float64 is NaN (exponent = 2047, mantissa != 0)
+//
+// LAMPE-LITERATE preamble: ../../proofs/helpers_f64_preamble.lean
+// LAMPE-LITERATE proof:    ../../proofs/helpers_f64_equivalence.lean fn=float64_is_nan name=float64_is_nan_equivalence
 pub fn float64_is_nan(x: IEEE754Float64) -> bool {
     (x.exponent == FLOAT64_EXPONENT_MAX) & (x.mantissa != 0)
 }


### PR DESCRIPTION
## Summary

Lands four trivial-tier (Tier 1) Lean equivalence theorems for the f64 bit-pattern classifiers in `ieee754/src/float64/helpers.nr`:

* `float64_is_nan_equivalence`
* `float64_is_infinity_equivalence`
* `float64_is_zero_equivalence`
* `float64_is_denormal_equivalence`

Each Noir helper hand-ports to a literal `(exponent EQ X) && (mantissa OP Y)` boolean in `helpers_f64_preamble.lean`; the matching theorem in `helpers_f64_equivalence.lean` reduces to `rfl` against the canonical `Equivalence.ModelsF64.{isNaN64,isInf64,isZero64,isDenormal64}` classifier.

`is_zero` correctly ignores the sign bit; both `+0` and `-0` map to `true`.

## Methodology

Wave 13 / Tier 1 (trivial). Mirrors the f32-helpers PR exactly, swapped to the binary64 layout (11-bit exponent, 52-bit mantissa). Same lampe-literate plumbing as PR #60.

## Verification

- [x] `nargo check` on `ieee754` — clean
- [x] `lampe-literate check ieee754/src/float64/helpers.nr` — directives parse, splice resolves the imported `ModelsF64.lean` symbols
- [ ] `lake build` end-to-end — offloaded to CI

## Test plan

- [ ] CI green on this branch
- [ ] Roborev review addressed