### PR TITLE
feat(proofs): scaffold div_f32_equivalence (sorry-stub)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ noir/lib/*/lampe/
 # module and the cached lake build. Regenerated from the literate Noir
 # directive lines each time `lampe-literate build` runs; never edited
 # by hand.
+# lampe-literate scratch dir (per-source). Contains the Lampe-extracted
+# Lean, the spliced proof module, and the cached lake build. Regenerated
+# from the literate Noir comment blocks each time `lampe-literate build`
+# runs; never edited by hand.
 **/.lampe-literate/
 
 # Node.js / semantic-release

--- a/ieee754/proofs/div_f32_equivalence.lean
+++ b/ieee754/proofs/div_f32_equivalence.lean
@@ -1,0 +1,85 @@
+/-!
+# Equivalence: optimised f32 div = reference f32 div (Tier 4 scaffold)
+
+Status: **sorry-stub**. Methodology documented; proof body to be filled by the
+next Lean specialist agent.
+
+## Methodology (skeleton-and-divergence, Tier 4)
+
+The optimised binary32 division at
+`circuits/noir_IEEE754/ieee754/src/float32/div.nr` uses **long division**
+via Noir's builtin `u64 / u64` after shifting the dividend left by 27 bits
+(24-bit significand + 3 guard bits). The remainder collapses into a sticky
+bit; classification (NaN / inf / zero / div-by-zero) follows the f32 add /
+mul shape.
+
+**Algorithm summary (optimised):**
+1. Classify both operands; handle special cases (NaN, inf, zero, div-by-zero
+   per IEEE 754-2019 sec.6.2 / sec.7.2).
+2. Normalise denormals via 5-step CLZ binary search (mirrors mul_f32 /
+   add_f32 helpers).
+3. `shifted_dividend = mant_a << 27`; `quotient = shifted_dividend /
+   mant_b`; `remainder = shifted_dividend % mant_b`.
+4. Normalise quotient (bit 27 vs bit 28 vs sub-1.0 left-shift).
+5. Sticky-bit OR-in if `remainder != 0`.
+6. RNE / directed-mode rounding via `should_round_up_4bit`.
+
+## Steps
+
+1. **Author a literal-spec reference** in
+   `circuits/noir_IEEE754/ieee754/reference/div_f32_reference.nr.ref`. The
+   reference can use the same long-division shape (Noir's builtin `/` on
+   `u64` is a deterministic, total operation -- no Newton-Raphson refinement
+   to verify), so the optimised and reference paths converge naturally on
+   the divide step. The reference deliberately does *not* fuse the
+   normalisation / rounding pipeline.
+2. **Hand-mirror both sides into Lean models** in `DivModelsF32.lean`. The
+   optimised model transcribes `div_float32_with_rounding` line for line;
+   the reference model transcribes the new `.nr.ref`.
+3. **Factor through `divF32Skeleton` with the divergence parameters** below.
+   Expected divergence sites (mirrors mul_f32 / mul_f64 patterns plus the
+   div-specific quotient-normalisation):
+   * **`rneDecision` / `should_round_up_4bit`** -- inline-RNE 4-bit shortcut
+     (div uses 4 guard bits, not 3) vs `Models.shouldRoundUp`. Author
+     `shouldRoundUp_inline_eq_4bit` analogously to round-9
+     `shouldRoundUp_inline_eq_3bit`. (NOTE: round 9 used 3 guard bits;
+     div uses 4 -- the constant in the inline form is the only delta.)
+   * **`stickyOfRemainder`** -- the optimised `if remainder != 0 { 1 }
+     else { 0 }` is a one-bit sticky test against the reference's
+     `Bool.toNat (remainder != 0)`-style spec. Trivial; closes by `rfl`
+     after `decide` unfolding.
+   * **`quotientNormalise`** -- the optimised path's two-`if` cascade
+     (`bit_28_set`, `bit_27_clear`) vs a reference `quotientNormaliseSpec`
+     that selects exactly one of three branches by case-split on
+     `quotient.toNat`'s leading bit. Author the equivalence as a 3-way
+     trichotomy lemma (round-6 add_f32 alignment-trichotomy is the
+     template).
+4. **Per-helper lemma audit.**
+   * `clzDenormalMantissa32` -- shared with mul_f32; reuse if mul_f32
+     scaffold lands first (per round-9 strategy: stay `sorry`-shared, or
+     close via `bv_decide`).
+   * Noir builtin `u64 / u64` and `u64 % u64` -- modelled on the Lean side
+     as `Nat.div` / `Nat.mod` after `BitVec.toNat`. The dispatch lemma is
+     `BitVec.toNat_div` / `BitVec.toNat_mod`; **shared** between optimised
+     and reference (no divergence parameter needed).
+5. **Tie together** with
+   `theorem div_f32_equivalence : divF32Optimised = divF32Reference`
+   following the round-9 one-liner: `unfold + rw [<divergence-param-eqs>]`.
+
+See `proofs/Ieee754/equivalence-spike-2026-05-04.md` round-9 entries and
+`proofs/Ieee754/ZkpSparql/Ieee754/Equivalence/MulF64.lean` for the worked
+methodology.
+-/
+
+/-- The optimised f32 div is bit-identical to the literal-IEEE-754 reference
+f32 div, for every input and every rounding mode. **Sorry-stub** -- proof
+body to be filled per the methodology comment above. -/
+theorem div_f32_equivalence : True := by
+  -- TODO: replace with
+  --   theorem div_f32_equivalence (a b : Float32Bits) (mode : BitVec 8) :
+  --       divF32Optimised a b mode = divF32Reference a b mode := by ...
+  -- once `divF32Optimised` and `divF32Reference` exist in
+  -- `ZkpSparql.Ieee754.Equivalence.DivModelsF32`.
+  sorry
+
+end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/div_f32_preamble.lean
+++ b/ieee754/proofs/div_f32_preamble.lean
@@ -1,0 +1,18 @@
+-- Imports for the eventual `div_f32_equivalence` closure.
+--
+-- The skeleton-and-divergence pattern (round 9 mul_f64) is the template;
+-- the per-op `DivModelsF32` / `SubtermsDivF32` modules will be authored
+-- by the Lean specialist closing this proof.
+import ZkpSparql.Ieee754.Equivalence.Spec
+import ZkpSparql.Ieee754.Equivalence.Subterms
+import ZkpSparql.Ieee754.Equivalence.Models
+-- Per-op modules (to be authored):
+-- import ZkpSparql.Ieee754.Equivalence.DivModelsF32
+-- import ZkpSparql.Ieee754.Equivalence.SubtermsDivF32
+
+namespace ZkpSparql.Ieee754.Equivalence
+
+open ZkpSparql.Ieee754.Equivalence.Models
+open ZkpSparql.Ieee754.Equivalence.Subterms
+-- open ZkpSparql.Ieee754.Equivalence.DivModelsF32
+-- open ZkpSparql.Ieee754.Equivalence.SubtermsDivF32

--- a/ieee754/reference/div_f32_reference.nr.ref
+++ b/ieee754/reference/div_f32_reference.nr.ref
@@ -1,0 +1,24 @@
+// IEEE 754 binary32 division -- literal-spec reference.
+//
+// Status: **TODO** -- placeholder for a hand-ported reference matching IEEE
+// 754-2019 sec.7.2 (division). The optimised path uses long division via
+// Noir's builtin `u64 / u64` after `<< 27`-shift of the dividend (24-bit
+// significand + 3 guard bits, plus a 4th guard via the 4-bit RNE shortcut).
+//
+// The reference body should:
+//   * Mirror the long-division shape (the divide step itself converges:
+//     Noir builtin `/` is deterministic, no Newton-Raphson iteration to
+//     verify).
+//   * Deliberately *not* fuse normalisation + rounding (kept as separate
+//     steps for traceability against IEEE 754-2019 sec.7.2).
+//   * Use the canonical `should_round_up` (4-bit guard) instead of the
+//     optimised inline-RNE shortcut, exposing the inline-RNE divergence
+//     parameter cleanly.
+//
+// Closure path (paired with `proofs/div_f32_equivalence.lean`):
+//   1. Hand-port the optimised algorithm with the de-fusions noted above.
+//   2. Hand-mirror both sides into `DivModelsF32` (Lean).
+//   3. Factor through `divF32Skeleton` with the divergence parameters
+//      enumerated in the proof file's doc-comment.
+//
+// See PROOF-GAP-MATRIX.md (Tier 4) and round-9 mul_f64 for the worked pattern.

--- a/ieee754/src/float32/div.nr
+++ b/ieee754/src/float32/div.nr
@@ -19,6 +19,17 @@ use crate::utils::{
 // `rounding_mode` must be one of the `ROUNDING_MODE_*` constants in
 // `crate::types` (i.e. `0..=4`). Any other value triggers an assertion
 // failure -- see `add_float32_with_rounding` for the rationale.
+//
+// ----------------------------------------------------------------------------
+// Lean equivalence proof (scaffold, sorry-stub). Tier 4 per
+// `proofs/Ieee754/PROOF-GAP-MATRIX.md`. Long-division algorithm (Noir
+// builtin `u64 / u64`); divergence parameters and per-helper recipe live
+// in the linked equivalence file's doc-comment.
+// ----------------------------------------------------------------------------
+//
+// LAMPE-LITERATE preamble:  ../../proofs/div_f32_preamble.lean
+// LAMPE-LITERATE proof:     ../../proofs/div_f32_equivalence.lean fn=div_float32_with_rounding name=div_f32_equivalence
+// LAMPE-LITERATE reference: ../../reference/div_f32_reference.nr.ref fn=div_float32_with_rounding name=div_f32_reference
 pub fn div_float32_with_rounding(
     a: IEEE754Float32,
     b: IEEE754Float32,


### PR DESCRIPTION
## Summary

Tier 4 scaffold per `proofs/Ieee754/PROOF-GAP-MATRIX.md` for binary32 division. Long-division algorithm via Noir's builtin `u64 / u64` after a 27-bit dividend shift; this PR lays the runway so the next Lean specialist can fill in the proof body.

- Closes-by-`sorry`. `lake build` accepts `sorry` and only emits a warning, so CI green is the bar.
- Methodology recipe lives inline in the equivalence file's doc-comment: divergence parameters (`rneDecision` 4-bit, `stickyOfRemainder`, `quotientNormalise` trichotomy) and per-helper share-or-strengthen audit.
- LAMPE-LITERATE directives only -- the optimised function body in `div.nr` is untouched.

## What landed

- `ieee754/proofs/div_f32_preamble.lean` -- imports + namespace open.
- `ieee754/proofs/div_f32_equivalence.lean` -- sorry-stub theorem + multi-line methodology doc-comment.
- `ieee754/reference/div_f32_reference.nr.ref` -- TODO placeholder.
- `LAMPE-LITERATE` preamble / proof / reference directives beside `pub fn div_float32_with_rounding(...)`.
- `**/.lampe-literate/` to `.gitignore`.

## Verification

- [x] `lampe-literate check` parses + materialises cleanly
- [x] `nargo check` green (only pre-existing `unsafe`/`Safety:` warnings)
- [ ] `lake build` -- deferred to CI / next-agent run

## Next agent

1. Author the literal-spec reference in `div_f32_reference.nr.ref` (de-fused normalisation + rounding pipeline; canonical `should_round_up`).
2. Add `DivModelsF32.lean` + `SubtermsDivF32.lean`.
3. Close via `unfold + rw [<divergence-param-eqs>]` -- the divide step itself converges (Noir `/` is deterministic).

Reference: `proofs/Ieee754/equivalence-spike-2026-05-04.md` (round 9), `proofs/Ieee754/ZkpSparql/Ieee754/Equivalence/MulF64.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)