### PR TITLE
proofs(f32 constructors): trivial-tier equivalences for nan/inf/zero/max_finite

### DIFF
--- a/ieee754/proofs/constructors_f32_equivalence.lean
+++ b/ieee754/proofs/constructors_f32_equivalence.lean
@@ -1,0 +1,19 @@
+/-! # Equivalence theorems: f32 constructors
+
+Each optimised hand-port equals the canonical constructor in
+`Equivalence.Models`. Both sides are the same `Float32Bits` struct
+literal after definitional unfolding, so `rfl` closes each goal. -/
+
+theorem float32_nan_equivalence :
+    float32NanOptimised = float32NaN := rfl
+
+theorem float32_infinity_equivalence (sign : BitVec 1) :
+    float32InfinityOptimised sign = float32Inf sign := rfl
+
+theorem float32_zero_equivalence (sign : BitVec 1) :
+    float32ZeroOptimised sign = float32Zero sign := rfl
+
+theorem float32_max_finite_equivalence (sign : BitVec 1) :
+    float32MaxFiniteOptimised sign = float32MaxFinite sign := rfl
+
+end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/constructors_f32_preamble.lean
+++ b/ieee754/proofs/constructors_f32_preamble.lean
@@ -1,0 +1,48 @@
+import ZkpSparql.Ieee754.Equivalence.Models
+
+namespace ZkpSparql.Ieee754.Equivalence
+
+open ZkpSparql.Ieee754.Equivalence.Models
+
+/-! # Trivial-tier helpers: bit-pattern constructors (f32)
+
+The Noir constructors `float32_nan`, `float32_infinity`,
+`float32_zero`, and `float32_max_finite` (in
+`ieee754/src/float32/helpers.nr`) build a `IEEE754Float32` struct
+from constant or sign-parameterised bit fields. The Lean models in
+`Equivalence.Models` (`float32NaN`, `float32Inf`, `float32Zero`,
+`float32MaxFinite`) mirror the same struct literals. Each
+equivalence theorem reduces to `rfl`.
+
+The encoding choices follow the Noir source bit-for-bit:
+
+* `nan` returns the canonical positive quiet NaN
+  (`sign = 0, exponent = 0xFF, mantissa = 0x400000`).
+* `infinity(sign)` keeps the requested sign with
+  `exponent = 0xFF, mantissa = 0`.
+* `zero(sign)` keeps the requested sign with
+  `exponent = 0, mantissa = 0` (so both `+0` and `-0` are valid).
+* `max_finite(sign)` returns the largest-magnitude finite,
+  `exponent = 0xFE, mantissa = 0x7FFFFF` (the IEEE 754-2019 sec
+  7.4 directed-rounding overflow saturation target). -/
+
+/-! ## Optimised models: literal hand-ports of the Noir bodies -/
+
+/-- Literal hand-port of `float32_nan` from
+`ieee754/src/float32/helpers.nr`. -/
+def float32NanOptimised : Float32Bits :=
+  { sign := 0, exponent := expMax, mantissa := 0x400000 }
+
+/-- Literal hand-port of `float32_infinity`. -/
+def float32InfinityOptimised (sign : BitVec 1) : Float32Bits :=
+  { sign := sign, exponent := expMax, mantissa := 0 }
+
+/-- Literal hand-port of `float32_zero`. -/
+def float32ZeroOptimised (sign : BitVec 1) : Float32Bits :=
+  { sign := sign, exponent := 0, mantissa := 0 }
+
+/-- Literal hand-port of `float32_max_finite`. The exponent is
+`FLOAT32_EXPONENT_MAX - 1 = 0xFE`; the mantissa is all-ones in the
+23-bit field, i.e. `0x7FFFFF`. -/
+def float32MaxFiniteOptimised (sign : BitVec 1) : Float32Bits :=
+  { sign := sign, exponent := 0xFE, mantissa := 0x7FFFFF }

--- a/ieee754/src/float32/helpers.nr
+++ b/ieee754/src/float32/helpers.nr
@@ -36,11 +36,17 @@ pub fn float32_nan() -> IEEE754Float32 {
 }
 
 // Create Float32 Infinity
+//
+// LAMPE-LITERATE preamble: ../../proofs/constructors_f32_preamble.lean
+// LAMPE-LITERATE proof:    ../../proofs/constructors_f32_equivalence.lean fn=float32_infinity name=float32_infinity_equivalence
 pub fn float32_infinity(sign: u1) -> IEEE754Float32 {
     IEEE754Float32 { sign, exponent: FLOAT32_EXPONENT_MAX, mantissa: 0 }
 }
 
 // Create Float32 Zero
+//
+// LAMPE-LITERATE preamble: ../../proofs/constructors_f32_preamble.lean
+// LAMPE-LITERATE proof:    ../../proofs/constructors_f32_equivalence.lean fn=float32_zero name=float32_zero_equivalence
 pub fn float32_zero(sign: u1) -> IEEE754Float32 {
     IEEE754Float32 { sign, exponent: 0, mantissa: 0 }
 }
@@ -48,6 +54,9 @@ pub fn float32_zero(sign: u1) -> IEEE754Float32 {
 // Create signed maximum-magnitude finite Float32
 // (the IEEE 754-2019 sec 7.4 directed-rounding overflow saturation target).
 // Encodes ``(2 - 2^-23) * 2^127`` with the requested sign (FLOAT32_MAX_NORMAL).
+//
+// LAMPE-LITERATE preamble: ../../proofs/constructors_f32_preamble.lean
+// LAMPE-LITERATE proof:    ../../proofs/constructors_f32_equivalence.lean fn=float32_max_finite name=float32_max_finite_equivalence
 pub fn float32_max_finite(sign: u1) -> IEEE754Float32 {
     IEEE754Float32 { sign, exponent: FLOAT32_EXPONENT_MAX - 1, mantissa: 0x7FFFFF }
 }

--- a/ieee754/src/float32/helpers.nr
+++ b/ieee754/src/float32/helpers.nr
@@ -28,6 +28,9 @@ pub fn float32_is_denormal(x: IEEE754Float32) -> bool {
 }
 
 // Create Float32 NaN
+//
+// LAMPE-LITERATE preamble: ../../proofs/constructors_f32_preamble.lean
+// LAMPE-LITERATE proof:    ../../proofs/constructors_f32_equivalence.lean fn=float32_nan name=float32_nan_equivalence
 pub fn float32_nan() -> IEEE754Float32 {
     IEEE754Float32 { sign: 0, exponent: FLOAT32_EXPONENT_MAX, mantissa: 0x400000 }
 }


### PR DESCRIPTION
## Summary

Lands four trivial-tier (Tier 1) Lean equivalence theorems for the f32 bit-pattern constructors in `ieee754/src/float32/helpers.nr`:

* `float32_nan_equivalence` — positive quiet NaN, `(0, 0xFF, 0x400000)`
* `float32_infinity_equivalence` — `(sign, 0xFF, 0)`
* `float32_zero_equivalence` — `(sign, 0, 0)`; both `+0` and `-0` valid
* `float32_max_finite_equivalence` — `(sign, 0xFE, 0x7FFFFF)`; IEEE 754-2019 sec 7.4 directed-rounding overflow saturation target

Each Noir constructor is a literal struct constructor. The optimised hand-port in `constructors_f32_preamble.lean` mirrors the Noir bit-pattern; the matching theorem reduces to `rfl` against the canonical `Equivalence.Models.{float32NaN,float32Inf,float32Zero,float32MaxFinite}`.

## Methodology

Wave 13 / Tier 1 (trivial). Same lampe-literate plumbing as PR #62 + #64.

## Verification

- [x] `nargo check` on `ieee754` — clean
- [x] `lampe-literate check ieee754/src/float32/helpers.nr` — directives parse, splice well-formed
- [ ] `lake build` end-to-end — offloaded to CI

## Test plan

- [ ] CI green on this branch
- [ ] Roborev review addressed