### PR TITLE
proofs(f64 constructors): trivial-tier equivalences for nan/inf/zero/max_finite

### DIFF
--- a/ieee754/proofs/constructors_f64_equivalence.lean
+++ b/ieee754/proofs/constructors_f64_equivalence.lean
@@ -1,0 +1,20 @@
+/-! # Equivalence theorems: f64 constructors
+
+Each optimised hand-port equals the canonical constructor in
+`Equivalence.ModelsF64`. Both sides are the same `Float64Bits`
+struct literal after definitional unfolding, so `rfl` closes each
+goal. -/
+
+theorem float64_nan_equivalence :
+    float64NanOptimised = float64NaN := rfl
+
+theorem float64_infinity_equivalence (sign : BitVec 1) :
+    float64InfinityOptimised sign = float64Inf sign := rfl
+
+theorem float64_zero_equivalence (sign : BitVec 1) :
+    float64ZeroOptimised sign = float64Zero sign := rfl
+
+theorem float64_max_finite_equivalence (sign : BitVec 1) :
+    float64MaxFiniteOptimised sign = float64MaxFinite sign := rfl
+
+end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/constructors_f64_preamble.lean
+++ b/ieee754/proofs/constructors_f64_preamble.lean
@@ -1,0 +1,47 @@
+import ZkpSparql.Ieee754.Equivalence.ModelsF64
+
+namespace ZkpSparql.Ieee754.Equivalence
+
+open ZkpSparql.Ieee754.Equivalence.ModelsF64
+
+/-! # Trivial-tier helpers: bit-pattern constructors (f64)
+
+The Noir constructors `float64_nan`, `float64_infinity`,
+`float64_zero`, and `float64_max_finite` (in
+`ieee754/src/float64/helpers.nr`) build a `IEEE754Float64` struct
+from constant or sign-parameterised bit fields. The Lean models in
+`Equivalence.ModelsF64` (`float64NaN`, `float64Inf`, `float64Zero`,
+`float64MaxFinite`) mirror the same struct literals. Each
+equivalence theorem reduces to `rfl`.
+
+Encoding choices follow the Noir source bit-for-bit:
+
+* `nan` returns the canonical positive quiet NaN
+  (`sign = 0, exponent = 2047, mantissa = 0x8000000000000`).
+* `infinity(sign)` keeps the requested sign with
+  `exponent = 2047, mantissa = 0`.
+* `zero(sign)` keeps the requested sign with
+  `exponent = 0, mantissa = 0`.
+* `max_finite(sign)` returns the largest-magnitude finite,
+  `exponent = 0x7FE, mantissa = 0xFFFFFFFFFFFFF` (the IEEE 754-2019
+  sec 7.4 directed-rounding overflow saturation target). -/
+
+/-! ## Optimised models: literal hand-ports of the Noir bodies -/
+
+/-- Literal hand-port of `float64_nan`. -/
+def float64NanOptimised : Float64Bits :=
+  { sign := 0, exponent := expMax64, mantissa := 0x8000000000000 }
+
+/-- Literal hand-port of `float64_infinity`. -/
+def float64InfinityOptimised (sign : BitVec 1) : Float64Bits :=
+  { sign := sign, exponent := expMax64, mantissa := 0 }
+
+/-- Literal hand-port of `float64_zero`. -/
+def float64ZeroOptimised (sign : BitVec 1) : Float64Bits :=
+  { sign := sign, exponent := 0, mantissa := 0 }
+
+/-- Literal hand-port of `float64_max_finite`. The exponent is
+`FLOAT64_EXPONENT_MAX - 1 = 0x7FE`; the mantissa is all-ones in the
+52-bit field, i.e. `0xFFFFFFFFFFFFF`. -/
+def float64MaxFiniteOptimised (sign : BitVec 1) : Float64Bits :=
+  { sign := sign, exponent := 0x7FE, mantissa := 0xFFFFFFFFFFFFF }

--- a/ieee754/src/float64/helpers.nr
+++ b/ieee754/src/float64/helpers.nr
@@ -33,11 +33,15 @@ pub fn float64_nan() -> IEEE754Float64 {
 }
 
 // Create Float64 Infinity
+//
+// LAMPE-LITERATE proof: ../../proofs/constructors_f64_equivalence.lean fn=float64_infinity name=float64_infinity_equivalence
 pub fn float64_infinity(sign: u1) -> IEEE754Float64 {
     IEEE754Float64 { sign, exponent: FLOAT64_EXPONENT_MAX, mantissa: 0 }
 }
 
 // Create Float64 Zero
+//
+// LAMPE-LITERATE proof: ../../proofs/constructors_f64_equivalence.lean fn=float64_zero name=float64_zero_equivalence
 pub fn float64_zero(sign: u1) -> IEEE754Float64 {
     IEEE754Float64 { sign, exponent: 0, mantissa: 0 }
 }
@@ -45,6 +49,8 @@ pub fn float64_zero(sign: u1) -> IEEE754Float64 {
 // Create signed maximum-magnitude finite Float64
 // (the IEEE 754-2019 sec 7.4 directed-rounding overflow saturation target).
 // Encodes ``(2 - 2^-52) * 2^1023`` with the requested sign (FLOAT64_MAX_NORMAL).
+//
+// LAMPE-LITERATE proof: ../../proofs/constructors_f64_equivalence.lean fn=float64_max_finite name=float64_max_finite_equivalence
 pub fn float64_max_finite(sign: u1) -> IEEE754Float64 {
     IEEE754Float64 { sign, exponent: FLOAT64_EXPONENT_MAX - 1, mantissa: 0xFFFFFFFFFFFFF }
 }

--- a/ieee754/src/float64/helpers.nr
+++ b/ieee754/src/float64/helpers.nr
@@ -25,6 +25,9 @@ pub fn float64_is_denormal(x: IEEE754Float64) -> bool {
 }
 
 // Create Float64 NaN
+//
+// LAMPE-LITERATE preamble: ../../proofs/constructors_f64_preamble.lean
+// LAMPE-LITERATE proof:    ../../proofs/constructors_f64_equivalence.lean fn=float64_nan name=float64_nan_equivalence
 pub fn float64_nan() -> IEEE754Float64 {
     IEEE754Float64 { sign: 0, exponent: FLOAT64_EXPONENT_MAX, mantissa: 0x8000000000000 }
 }


### PR DESCRIPTION
## Summary

Lands four trivial-tier (Tier 1) Lean equivalence theorems for the f64 bit-pattern constructors in `ieee754/src/float64/helpers.nr`:

* `float64_nan_equivalence` — `(0, 2047, 0x8000000000000)`
* `float64_infinity_equivalence` — `(sign, 2047, 0)`
* `float64_zero_equivalence` — `(sign, 0, 0)`
* `float64_max_finite_equivalence` — `(sign, 0x7FE, 0xFFFFFFFFFFFFF)`; IEEE 754-2019 sec 7.4 saturation target

Each theorem reduces to `rfl` against `Equivalence.ModelsF64`.

## Methodology

Wave 13 / Tier 1 (trivial). Mirrors the f32-constructors PR (#66).

## Verification

- [x] `nargo check` on `ieee754` — clean
- [x] `lampe-literate check` — splice well-formed
- [ ] `lake build` end-to-end — offloaded to CI

## Test plan

- [ ] CI green on this branch
- [ ] Roborev review addressed