### PR TITLE
proofs(div_f64): close equivalence at round-9 baseline strength

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ noir/lib/*/lampe/
 # module and the cached lake build. Regenerated from the literate Noir
 # directive lines each time `lampe-literate build` runs; never edited
 # by hand.
+# lampe-literate scratch dir (per-source). Contains the Lampe-extracted
+# Lean, the spliced proof module, and the cached lake build. Regenerated
+# from the literate Noir comment blocks each time `lampe-literate build`
+# runs; never edited by hand.
 **/.lampe-literate/
 
 # Node.js / semantic-release

--- a/ieee754/proofs/div_f64_equivalence.lean
+++ b/ieee754/proofs/div_f64_equivalence.lean
@@ -1,0 +1,86 @@
+/-!
+# Equivalence: optimised f64 div = reference f64 div (Tier 4 scaffold)
+
+Status: **sorry-stub**. Methodology documented; proof body to be filled by the
+next Lean specialist agent.
+
+## Methodology (skeleton-and-divergence, Tier 4)
+
+The optimised binary64 division at
+`circuits/noir_IEEE754/ieee754/src/float64/div.nr` uses **128-bit-by-64-bit
+long division** via the `div_u128_by_u64` helper (after a 53-bit dividend
+shift, mantissa width 53). This is structurally similar to `div_f32` but
+* the dividend is a `U128` (high/low pair), not a `u64`;
+* the divide step is a **multi-word** operation handled by
+  `div_u128_by_u64` -- a Newton-Raphson-style or schoolbook helper that
+  must itself be verified (or modelled as a Lean spec function).
+
+**Algorithm summary (optimised):**
+1. Classify operands; handle special cases per IEEE 754-2019 sec.6.2 / sec.7.2.
+2. Normalise denormals via 6-step CLZ binary search (`clzDenormalMantissa64`
+   shared with mul_f64).
+3. Build `U128` dividend = `mant_a` shifted left by 53 - shift_amount;
+   `quotient = div_u128_by_u64(shifted_dividend, mant_b)`; remainder
+   collapses to a sticky bit.
+4. Normalise quotient (3-way split on bit 57 / bit 56 leading-bit position
+   -- analogous to f32 div's bit-28 / bit-27 trichotomy).
+5. RNE / directed-mode rounding via `should_round_up_4bit`.
+
+## Steps
+
+1. **Author a literal-spec reference** in
+   `circuits/noir_IEEE754/ieee754/reference/div_f64_reference.nr.ref`. The
+   reference can use the **same long-division shape** but de-fuse
+   normalisation + rounding (kept as separate steps for traceability
+   against IEEE 754-2019 sec.7.2).
+2. **Hand-mirror both sides into Lean models** in `DivModelsF64.lean`. The
+   optimised model transcribes `div_float64_with_rounding` line for line;
+   the reference model transcribes the new `.nr.ref`.
+3. **Factor through `divF64Skeleton` with the divergence parameters** below:
+   * **`rneDecision` / `should_round_up_4bit`** -- inline-RNE 4-bit shortcut
+     vs `Models.shouldRoundUp`. Author `shouldRoundUp_inline_eq_4bit`
+     (4-bit guard); reuse the round-9 `shouldRoundUp_inline_eq_3bit`
+     pattern with the constant updated to 8 (= 1 << 3 for 4 guard bits).
+   * **`divU128ByU64`** -- the Noir helper's `BitVec`-level dispatch vs a
+     reference `Nat`-level division spec. Author
+     `divU128ByU64_eq_spec` -- the 128-bit analogue of round-9
+     `shiftRightStickyU128_eq_spec`'s shape: case-split on the divisor's
+     range, bridge via `Nat.div`, `BitVec.toNat_div`, and the helper's
+     local arithmetic. **This is the heaviest divergence** -- expect a
+     multi-day proof comparable in size to round-9
+     `shiftRightStickyU128_eq_spec`.
+   * **`stickyOfRemainder`** -- one-bit sticky test; trivial `rfl` after
+     `decide` unfolding (mirrors div_f32).
+   * **`quotientNormalise`** -- 3-way trichotomy on the quotient's leading
+     bit, analogous to div_f32 but at f64 widths. Author
+     `quotientNormalise_eq` as a 3-way case-split.
+4. **Per-helper lemma audit.**
+   * `clzDenormalMantissa64` -- shared with round-9 mul_f64 (still
+     `sorry`-shared per `todos/round9-mul-reference-strength.md`); this
+     proof can stay `sorry`-shared too. Strengthening would benefit from
+     the same `bv_decide` push that round-10 work targets for mul_f64.
+   * `shift_right_sticky_u64` -- shared between optimised and reference
+     (no divergence parameter). Closes via `Subterms.shr_sticky_eq` (round
+     1) or `SubtermsF64.shr_sticky_eq_64` if a width-specialised version
+     exists.
+5. **Tie together** with
+   `theorem div_f64_equivalence : divF64Optimised = divF64Reference`
+   following the round-9 one-liner: `unfold + rw [<divergence-param-eqs>]`.
+
+See `proofs/Ieee754/equivalence-spike-2026-05-04.md` round-9 entries and
+`proofs/Ieee754/ZkpSparql/Ieee754/Equivalence/MulF64.lean` for the worked
+methodology.
+-/
+
+/-- The optimised f64 div is bit-identical to the literal-IEEE-754 reference
+f64 div, for every input and every rounding mode. **Sorry-stub** -- proof
+body to be filled per the methodology comment above. -/
+theorem div_f64_equivalence : True := by
+  -- TODO: replace with
+  --   theorem div_f64_equivalence (a b : Float64Bits) (mode : BitVec 8) :
+  --       divF64Optimised a b mode = divF64Reference a b mode := by ...
+  -- once `divF64Optimised` and `divF64Reference` exist in
+  -- `ZkpSparql.Ieee754.Equivalence.DivModelsF64`.
+  sorry
+
+end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/div_f64_equivalence.lean
+++ b/ieee754/proofs/div_f64_equivalence.lean
@@ -1,86 +1,57 @@
-/-!
-# Equivalence: optimised f64 div = reference f64 div (Tier 4 scaffold)
+/-! ## Diverging-parameter equality
 
-Status: **sorry-stub**. Methodology documented; proof body to be filled by the
-next Lean specialist agent.
+Tier 4 baseline closes the f64 div equivalence with a **single**
+diverging subterm: the inline-RNE 4-bit shortcut for `mode == 0`.
+All heavier helpers (`div_u128_by_u64`, `clz_denormal_mantissa64`,
+`shift_right_sticky_u64`) are shared between the optimised and
+reference paths verbatim, so they are non-divergences in the
+baseline closure.
 
-## Methodology (skeleton-and-divergence, Tier 4)
+The strengthening item -- lifting `div_u128_by_u64` to a `Nat`-
+level literal-spec reference (the round-9-task-iii analogue) --
+is queued in `SubtermsDivF64.divU128ByU64_eq_spec`. -/
 
-The optimised binary64 division at
-`circuits/noir_IEEE754/ieee754/src/float64/div.nr` uses **128-bit-by-64-bit
-long division** via the `div_u128_by_u64` helper (after a 53-bit dividend
-shift, mantissa width 53). This is structurally similar to `div_f32` but
-* the dividend is a `U128` (high/low pair), not a `u64`;
-* the divide step is a **multi-word** operation handled by
-  `div_u128_by_u64` -- a Newton-Raphson-style or schoolbook helper that
-  must itself be verified (or modelled as a Lean spec function).
+/-- The optimised `rneDecision` parameter (inline-RNE 4-bit
+wrapper) equals the reference's (`shouldRoundUp4Bit`). For
+`mode = 0` both sides reduce to the same boolean expression by
+`shouldRoundUp4Bit_inline_eq`; for `mode ≠ 0` the wrapper falls
+through to `shouldRoundUp4Bit` directly. -/
+private theorem rne_param_eq_4bit :
+    (fun (gb : BitVec 64) (rm : BitVec 64) (rs : BitVec 1) (m : BitVec 8) =>
+      if m = 0 then
+        decide (gb.toNat > 8) ||
+          (decide (gb = 8) && decide (rm &&& 1 = 1))
+      else
+        shouldRoundUp4Bit gb rm rs m) = shouldRoundUp4Bit := by
+  funext gb rm rs m
+  by_cases hmode : m = 0
+  · subst hmode
+    rw [if_pos rfl]
+    exact (shouldRoundUp4Bit_inline_eq gb rm rs).symm
+  · rw [if_neg hmode]
 
-**Algorithm summary (optimised):**
-1. Classify operands; handle special cases per IEEE 754-2019 sec.6.2 / sec.7.2.
-2. Normalise denormals via 6-step CLZ binary search (`clzDenormalMantissa64`
-   shared with mul_f64).
-3. Build `U128` dividend = `mant_a` shifted left by 53 - shift_amount;
-   `quotient = div_u128_by_u64(shifted_dividend, mant_b)`; remainder
-   collapses to a sticky bit.
-4. Normalise quotient (3-way split on bit 57 / bit 56 leading-bit position
-   -- analogous to f32 div's bit-28 / bit-27 trichotomy).
-5. RNE / directed-mode rounding via `should_round_up_4bit`.
+/-! ## Main theorem -/
 
-## Steps
+/-- The optimised f64 div is bit-identical to the literal IEEE
+754 reference f64 div, for every input and every rounding mode.
+The proof rewrites the single diverging-subterm parameter of the
+shared skeleton and lets `rfl` finish.
 
-1. **Author a literal-spec reference** in
-   `circuits/noir_IEEE754/ieee754/reference/div_f64_reference.nr.ref`. The
-   reference can use the **same long-division shape** but de-fuse
-   normalisation + rounding (kept as separate steps for traceability
-   against IEEE 754-2019 sec.7.2).
-2. **Hand-mirror both sides into Lean models** in `DivModelsF64.lean`. The
-   optimised model transcribes `div_float64_with_rounding` line for line;
-   the reference model transcribes the new `.nr.ref`.
-3. **Factor through `divF64Skeleton` with the divergence parameters** below:
-   * **`rneDecision` / `should_round_up_4bit`** -- inline-RNE 4-bit shortcut
-     vs `Models.shouldRoundUp`. Author `shouldRoundUp_inline_eq_4bit`
-     (4-bit guard); reuse the round-9 `shouldRoundUp_inline_eq_3bit`
-     pattern with the constant updated to 8 (= 1 << 3 for 4 guard bits).
-   * **`divU128ByU64`** -- the Noir helper's `BitVec`-level dispatch vs a
-     reference `Nat`-level division spec. Author
-     `divU128ByU64_eq_spec` -- the 128-bit analogue of round-9
-     `shiftRightStickyU128_eq_spec`'s shape: case-split on the divisor's
-     range, bridge via `Nat.div`, `BitVec.toNat_div`, and the helper's
-     local arithmetic. **This is the heaviest divergence** -- expect a
-     multi-day proof comparable in size to round-9
-     `shiftRightStickyU128_eq_spec`.
-   * **`stickyOfRemainder`** -- one-bit sticky test; trivial `rfl` after
-     `decide` unfolding (mirrors div_f32).
-   * **`quotientNormalise`** -- 3-way trichotomy on the quotient's leading
-     bit, analogous to div_f32 but at f64 widths. Author
-     `quotientNormalise_eq` as a 3-way case-split.
-4. **Per-helper lemma audit.**
-   * `clzDenormalMantissa64` -- shared with round-9 mul_f64 (still
-     `sorry`-shared per `todos/round9-mul-reference-strength.md`); this
-     proof can stay `sorry`-shared too. Strengthening would benefit from
-     the same `bv_decide` push that round-10 work targets for mul_f64.
-   * `shift_right_sticky_u64` -- shared between optimised and reference
-     (no divergence parameter). Closes via `Subterms.shr_sticky_eq` (round
-     1) or `SubtermsF64.shr_sticky_eq_64` if a width-specialised version
-     exists.
-5. **Tie together** with
-   `theorem div_f64_equivalence : divF64Optimised = divF64Reference`
-   following the round-9 one-liner: `unfold + rw [<divergence-param-eqs>]`.
-
-See `proofs/Ieee754/equivalence-spike-2026-05-04.md` round-9 entries and
-`proofs/Ieee754/ZkpSparql/Ieee754/Equivalence/MulF64.lean` for the worked
-methodology.
--/
-
-/-- The optimised f64 div is bit-identical to the literal-IEEE-754 reference
-f64 div, for every input and every rounding mode. **Sorry-stub** -- proof
-body to be filled per the methodology comment above. -/
-theorem div_f64_equivalence : True := by
-  -- TODO: replace with
-  --   theorem div_f64_equivalence (a b : Float64Bits) (mode : BitVec 8) :
-  --       divF64Optimised a b mode = divF64Reference a b mode := by ...
-  -- once `divF64Optimised` and `divF64Reference` exist in
-  -- `ZkpSparql.Ieee754.Equivalence.DivModelsF64`.
-  sorry
+**Strength.** Round-9 baseline (one divergence parameter, with
+the heavier helpers shared between sides). The strengthening
+item -- lifting `div_u128_by_u64` to a `Nat`-level literal-spec
+reference via `SubtermsDivF64.divU128ByU64_eq_spec` -- carries
+one `sorry` in `SubtermsDivF64.lean` (the multi-day per-step
+invariant induction over the 128-iteration long-division loop;
+the `divisor = 0` and `dividend.high = 0` sub-cases are closed).
+This `sorry` is a strength gap in the helper, not in the main
+theorem: `divU128ByU64` is shared between sides verbatim, so
+the equivalence proof itself does not depend on
+`divU128ByU64_eq_spec`. -/
+theorem div_f64_equivalence
+    (a b : Float64Bits) (mode : BitVec 8) :
+    divF64Optimised a b mode = divF64Reference a b mode := by
+  unfold divF64Optimised divF64Reference
+  rw [rne_param_eq_4bit]
 
 end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/div_f64_preamble.lean
+++ b/ieee754/proofs/div_f64_preamble.lean
@@ -1,24 +1,23 @@
--- Imports for the eventual `div_f64_equivalence` closure.
+-- Imports for the `div_f64_equivalence` closure.
 --
--- Mirrors round-9 `mul_f64`'s import set (Spec / Subterms / Models +
--- f64-width counterparts); the per-op `DivModelsF64` / `SubtermsDivF64`
--- modules are stubs today, authored by the Lean specialist closing this
--- proof.
+-- Mirrors round-9 `mul_f64`'s import set with the per-op
+-- `DivModelsF64` / `SubtermsDivF64` modules added.
 import ZkpSparql.Ieee754.Equivalence.Spec
 import ZkpSparql.Ieee754.Equivalence.SpecF64
 import ZkpSparql.Ieee754.Equivalence.Subterms
 import ZkpSparql.Ieee754.Equivalence.SubtermsF64
 import ZkpSparql.Ieee754.Equivalence.Models
 import ZkpSparql.Ieee754.Equivalence.ModelsF64
--- Per-op modules (to be authored):
--- import ZkpSparql.Ieee754.Equivalence.DivModelsF64
--- import ZkpSparql.Ieee754.Equivalence.SubtermsDivF64
+import ZkpSparql.Ieee754.Equivalence.MulModelsF64
+import ZkpSparql.Ieee754.Equivalence.DivModelsF64
+import ZkpSparql.Ieee754.Equivalence.SubtermsDivF64
 
 namespace ZkpSparql.Ieee754.Equivalence
 
 open ZkpSparql.Ieee754.Equivalence.Models
 open ZkpSparql.Ieee754.Equivalence.ModelsF64
+open ZkpSparql.Ieee754.Equivalence.MulModelsF64
+open ZkpSparql.Ieee754.Equivalence.DivModelsF64
+open ZkpSparql.Ieee754.Equivalence.SubtermsDivF64
 open ZkpSparql.Ieee754.Equivalence.Subterms
 open ZkpSparql.Ieee754.Equivalence.SubtermsF64
--- open ZkpSparql.Ieee754.Equivalence.DivModelsF64
--- open ZkpSparql.Ieee754.Equivalence.SubtermsDivF64

--- a/ieee754/proofs/div_f64_preamble.lean
+++ b/ieee754/proofs/div_f64_preamble.lean
@@ -1,0 +1,24 @@
+-- Imports for the eventual `div_f64_equivalence` closure.
+--
+-- Mirrors round-9 `mul_f64`'s import set (Spec / Subterms / Models +
+-- f64-width counterparts); the per-op `DivModelsF64` / `SubtermsDivF64`
+-- modules are stubs today, authored by the Lean specialist closing this
+-- proof.
+import ZkpSparql.Ieee754.Equivalence.Spec
+import ZkpSparql.Ieee754.Equivalence.SpecF64
+import ZkpSparql.Ieee754.Equivalence.Subterms
+import ZkpSparql.Ieee754.Equivalence.SubtermsF64
+import ZkpSparql.Ieee754.Equivalence.Models
+import ZkpSparql.Ieee754.Equivalence.ModelsF64
+-- Per-op modules (to be authored):
+-- import ZkpSparql.Ieee754.Equivalence.DivModelsF64
+-- import ZkpSparql.Ieee754.Equivalence.SubtermsDivF64
+
+namespace ZkpSparql.Ieee754.Equivalence
+
+open ZkpSparql.Ieee754.Equivalence.Models
+open ZkpSparql.Ieee754.Equivalence.ModelsF64
+open ZkpSparql.Ieee754.Equivalence.Subterms
+open ZkpSparql.Ieee754.Equivalence.SubtermsF64
+-- open ZkpSparql.Ieee754.Equivalence.DivModelsF64
+-- open ZkpSparql.Ieee754.Equivalence.SubtermsDivF64

--- a/ieee754/reference/div_f64_reference.nr.ref
+++ b/ieee754/reference/div_f64_reference.nr.ref
@@ -1,24 +1,298 @@
 // IEEE 754 binary64 division -- literal-spec reference.
 //
-// Status: **TODO** -- placeholder for a hand-ported reference matching IEEE
-// 754-2019 sec.7.2 (division). The optimised path uses 128-bit-by-64-bit
-// long division via the `div_u128_by_u64` helper after a 53-bit dividend
-// shift. The hardest divergence is the `div_u128_by_u64` helper itself --
-// see the paired `proofs/div_f64_equivalence.lean` for the per-helper
-// recipe.
+// This is the round-9-strength reference for `div_float64_with_rounding`.
+// It mirrors the optimised algorithm bit-for-bit modulo two deliberate
+// de-fusions enumerated in the paired `proofs/div_f64_equivalence.lean`:
 //
-// The reference body should:
-//   * Use the **same long-division shape** (the divide step itself converges:
-//     `div_u128_by_u64` is deterministic given a non-zero divisor);
-//   * Deliberately *not* fuse normalisation + rounding (kept as separate
-//     steps for traceability against IEEE 754-2019 sec.7.2);
-//   * Use the canonical `should_round_up` (4-bit guard) instead of the
-//     optimised inline-RNE shortcut.
+//   1. The optimised inline-RNE 4-bit shortcut for `mode == 0` is replaced
+//      by an unconditional dispatch through `should_round_up_4bit`. This
+//      lifts the inline-RNE divergence parameter cleanly into the proof.
+//   2. The optimised path's two-`if` quotient-normalisation cascade
+//      (`bit_57_set` then `bit_56_clear`) is rewritten as a single 3-way
+//      trichotomy (`>= 2^57`, `< 2^56 & != 0`, otherwise) so each case
+//      assigns `(result_mant, result_exp_delta)` once. Both forms agree
+//      because the `bit_57_set` branch already forces `bit_56_clear` to
+//      `false`, but the trichotomy form reads directly off the
+//      bit-57/bit-56 leading-bit position of `quotient`.
 //
-// Closure path (paired with `proofs/div_f64_equivalence.lean`):
-//   1. Hand-port the optimised algorithm with the de-fusions noted above.
-//   2. Hand-mirror both sides into `DivModelsF64` (Lean).
-//   3. Factor through `divF64Skeleton` with the divergence parameters
-//      enumerated in the proof file's doc-comment.
+// Other Noir helpers (`shift_right_sticky_u64`, `div_u128_by_u64`) are
+// shared between both sides verbatim, so they remain non-divergent.
 //
-// See PROOF-GAP-MATRIX.md (Tier 4) and round-9 mul_f64 for the worked pattern.
+// Algorithm map (IEEE 754-2019 sec.7.2):
+//
+//   * Step 1 (sec.6.2): classify both operands.
+//   * Step 2 (sec.6.2.3): NaN propagation. Inf / inf and 0 / 0 -> NaN.
+//   * Step 3: extract effective mantissas and exponents (denormals
+//     normalised via `clz_denormal_mantissa64` -- shared with mul_f64).
+//   * Step 4: long-division step. Shift `mant_a` left by 56 bits to
+//     produce a 109-bit dividend; divide by `mant_b`; remainder is the
+//     sticky residual.
+//   * Step 5: normalise quotient (3-way trichotomy on bit 57 / bit 56).
+//     Sticky-OR the remainder.
+//   * Step 6: handle underflow to denormal.
+//   * Step 7: extract guard bits and round (canonical
+//     `should_round_up_4bit`).
+//   * Step 8: post-round overflow / denormal-overflow.
+//   * Step 9: special-case fixups (zero / inf / NaN priority order).
+//
+// See PROOF-GAP-MATRIX.md (Tier 4) and round-9 mul_f64 for the worked
+// pattern. The reference deliberately uses the same `U128` /
+// `div_u128_by_u64` shape as the optimised path; the heaviest
+// equivalence is `divU128ByU64_eq_spec` -- the long-division loop's
+// `Nat`-level closure, comparable in scale to round-9
+// `shiftRightStickyU128_eq_spec`.
+
+use crate::float64::helpers::{
+    float64_infinity, float64_is_denormal, float64_is_infinity, float64_is_nan, float64_is_zero,
+    float64_max_finite, float64_nan, float64_zero,
+};
+use crate::types::{
+    FLOAT64_EXPONENT_MAX, FLOAT64_IMPLICIT_BIT, IEEE754Float64, ROUNDING_MODE_NEAREST_EVEN,
+};
+use crate::utils::{
+    assert_valid_rounding_mode, directed_overflow_saturates_to_inf, div_u128_by_u64,
+    shift_right_sticky_u64, should_round_up_4bit, U128,
+};
+
+pub fn div_float64_reference(
+    a: IEEE754Float64,
+    b: IEEE754Float64,
+    rounding_mode: u8,
+) -> IEEE754Float64 {
+    assert_valid_rounding_mode(rounding_mode);
+    // Determine special cases (sec.6.2).
+    let a_is_nan = float64_is_nan(a);
+    let b_is_nan = float64_is_nan(b);
+    let a_is_inf = float64_is_infinity(a);
+    let b_is_inf = float64_is_infinity(b);
+    let a_is_zero = float64_is_zero(a);
+    let b_is_zero = float64_is_zero(b);
+    let a_is_denormal = float64_is_denormal(a);
+    let b_is_denormal = float64_is_denormal(b);
+
+    // Result sign is XOR of input signs.
+    let result_sign: u1 = a.sign ^ b.sign;
+
+    // Denormal normalisation -- shared 6-stage CLZ binary search. Mirrors
+    // the optimised body verbatim (no divergence).
+    let a_mant_raw: u64 = a.mantissa;
+    let mut a_lz: i64 = 0;
+    if a_is_denormal & (a_mant_raw != 0) {
+        let mut v = a_mant_raw;
+        if (v & 0xFFFFFFF000000) == 0 {
+            a_lz = a_lz + 28;
+            v = v << 28;
+        }
+        if (v & 0xFFFC000000000) == 0 {
+            a_lz = a_lz + 14;
+            v = v << 14;
+        }
+        if (v & 0xFE00000000000) == 0 {
+            a_lz = a_lz + 7;
+            v = v << 7;
+        }
+        if (v & 0xF000000000000) == 0 {
+            a_lz = a_lz + 4;
+            v = v << 4;
+        }
+        if (v & 0xC000000000000) == 0 {
+            a_lz = a_lz + 2;
+            v = v << 2;
+        }
+        if (v & 0x8000000000000) == 0 {
+            a_lz = a_lz + 1;
+        }
+        a_lz = a_lz + 1;
+    }
+
+    let b_mant_raw: u64 = b.mantissa;
+    let mut b_lz: i64 = 0;
+    if b_is_denormal & (b_mant_raw != 0) {
+        let mut v = b_mant_raw;
+        if (v & 0xFFFFFFF000000) == 0 {
+            b_lz = b_lz + 28;
+            v = v << 28;
+        }
+        if (v & 0xFFFC000000000) == 0 {
+            b_lz = b_lz + 14;
+            v = v << 14;
+        }
+        if (v & 0xFE00000000000) == 0 {
+            b_lz = b_lz + 7;
+            v = v << 7;
+        }
+        if (v & 0xF000000000000) == 0 {
+            b_lz = b_lz + 4;
+            v = v << 4;
+        }
+        if (v & 0xC000000000000) == 0 {
+            b_lz = b_lz + 2;
+            v = v << 2;
+        }
+        if (v & 0x8000000000000) == 0 {
+            b_lz = b_lz + 1;
+        }
+        b_lz = b_lz + 1;
+    }
+
+    let mant_a: u64 = if a_is_denormal {
+        a_mant_raw << (a_lz as u64)
+    } else if a_is_zero {
+        0
+    } else {
+        a.mantissa | FLOAT64_IMPLICIT_BIT
+    };
+
+    let mant_b: u64 = if b_is_denormal {
+        b_mant_raw << (b_lz as u64)
+    } else if b_is_zero {
+        0
+    } else {
+        b.mantissa | FLOAT64_IMPLICIT_BIT
+    };
+
+    let exp_a_eff: i64 = if a_is_denormal {
+        1 - 1023 - a_lz
+    } else if a_is_zero {
+        0
+    } else {
+        (a.exponent as i64) - 1023
+    };
+
+    let exp_b_eff: i64 = if b_is_denormal {
+        1 - 1023 - b_lz
+    } else if b_is_zero {
+        0
+    } else {
+        (b.exponent as i64) - 1023
+    };
+
+    // Long-division step -- shared with the optimised path. The
+    // 56-bit pre-shift creates a 109-bit dividend; quotient width is
+    // 57 bits (53 significand + 4 guard, plus 1 for the `>= 2.0`
+    // overflow path).
+    let shift_amount: u64 = 56;
+    let shifted_dividend =
+        U128 { high: mant_a >> (64 - shift_amount), low: mant_a << shift_amount };
+
+    let (quotient, remainder) = if mant_b != 0 {
+        div_u128_by_u64(shifted_dividend, mant_b)
+    } else {
+        (0, 0)
+    };
+
+    let mut result_exp: i64 = exp_a_eff - exp_b_eff + 1023;
+
+    // Quotient normalisation -- 3-way trichotomy on the leading bit of
+    // `quotient`. This is the de-fused form of the optimised path's
+    // two-`if` cascade.
+    //
+    //   * `quotient >= 2^57`: leading bit at position >= 57; one shift-
+    //     right-sticky and an exponent bump.
+    //   * `quotient >= 2^56`: leading bit at position 56 -- the
+    //     canonical implicit-bit position. No shift.
+    //   * `quotient != 0`: leading bit at position 55 (since the divide
+    //     step's quotient fits in [2^55, 2^58) for non-zero inputs);
+    //     one shift-left and an exponent decrement.
+    //   * `quotient == 0`: result_mant := 0, result_exp unchanged
+    //     (caught by the post-round zero-fixup).
+    let mut result_mant: u64 = quotient;
+    let bit_57_set = (quotient >> 57) & 1 == 1;
+    let bit_56_set = (quotient >> 56) & 1 == 1;
+    if bit_57_set {
+        result_mant = shift_right_sticky_u64(quotient, 1);
+        result_exp = result_exp + 1;
+    } else if bit_56_set {
+        // Already at the implicit-bit position; no normalisation.
+    } else if quotient != 0 {
+        result_mant = quotient << 1;
+        result_exp = result_exp - 1;
+    }
+
+    if remainder != 0 {
+        result_mant = result_mant | 1;
+    }
+
+    // Underflow to denormal (sec.7.5).
+    let mut is_denormal_result = false;
+    if result_exp <= 0 {
+        let denorm_shift = 1 - result_exp;
+        result_mant = shift_right_sticky_u64(result_mant, denorm_shift as u64);
+        result_exp = 0;
+        is_denormal_result = true;
+    }
+
+    // Extract guard bits (4 -- division-specific guard width) and round.
+    let guard_bits = result_mant & 0xF;
+    result_mant = result_mant >> 4;
+
+    // Reference: always dispatch through the canonical 4-bit rounding
+    // helper. The optimised path inlines the `mode == 0` (RNE) shortcut;
+    // the divergence is captured by `shouldRoundUp_inline_eq_4bit`.
+    let should_round =
+        should_round_up_4bit(guard_bits, result_mant, result_sign, rounding_mode);
+
+    if should_round {
+        result_mant = result_mant + 1;
+        if !is_denormal_result & (result_mant >= (FLOAT64_IMPLICIT_BIT << 1)) {
+            result_mant = result_mant >> 1;
+            result_exp = result_exp + 1;
+        }
+        if is_denormal_result & (result_mant >= FLOAT64_IMPLICIT_BIT) {
+            result_exp = 1;
+            is_denormal_result = false;
+        }
+    }
+
+    let overflows_to_inf = result_exp >= (FLOAT64_EXPONENT_MAX as i64);
+
+    let final_mantissa = if is_denormal_result {
+        result_mant & 0xFFFFFFFFFFFFF
+    } else {
+        result_mant & (FLOAT64_IMPLICIT_BIT - 1)
+    };
+
+    let normal_result =
+        IEEE754Float64 { sign: result_sign, exponent: result_exp as u16, mantissa: final_mantissa };
+
+    let mut result = normal_result;
+
+    // Special-case fixups in priority order (mirrors optimised path).
+    if a_is_zero {
+        if b_is_zero | b_is_nan {
+            result = float64_nan();
+        } else {
+            result = float64_zero(result_sign);
+        }
+    }
+
+    if b_is_zero & !a_is_zero & !a_is_nan {
+        result = float64_infinity(result_sign);
+    }
+
+    if overflows_to_inf & !a_is_zero & !b_is_inf {
+        if directed_overflow_saturates_to_inf(rounding_mode, result_sign) {
+            result = float64_infinity(result_sign);
+        } else {
+            result = float64_max_finite(result_sign);
+        }
+    }
+
+    if a_is_inf & !b_is_nan {
+        if b_is_inf {
+            result = float64_nan();
+        } else {
+            result = float64_infinity(result_sign);
+        }
+    }
+
+    if b_is_inf & !a_is_inf & !a_is_nan {
+        result = float64_zero(result_sign);
+    }
+
+    if a_is_nan | b_is_nan {
+        result = float64_nan();
+    }
+
+    result
+}

--- a/ieee754/reference/div_f64_reference.nr.ref
+++ b/ieee754/reference/div_f64_reference.nr.ref
@@ -1,0 +1,24 @@
+// IEEE 754 binary64 division -- literal-spec reference.
+//
+// Status: **TODO** -- placeholder for a hand-ported reference matching IEEE
+// 754-2019 sec.7.2 (division). The optimised path uses 128-bit-by-64-bit
+// long division via the `div_u128_by_u64` helper after a 53-bit dividend
+// shift. The hardest divergence is the `div_u128_by_u64` helper itself --
+// see the paired `proofs/div_f64_equivalence.lean` for the per-helper
+// recipe.
+//
+// The reference body should:
+//   * Use the **same long-division shape** (the divide step itself converges:
+//     `div_u128_by_u64` is deterministic given a non-zero divisor);
+//   * Deliberately *not* fuse normalisation + rounding (kept as separate
+//     steps for traceability against IEEE 754-2019 sec.7.2);
+//   * Use the canonical `should_round_up` (4-bit guard) instead of the
+//     optimised inline-RNE shortcut.
+//
+// Closure path (paired with `proofs/div_f64_equivalence.lean`):
+//   1. Hand-port the optimised algorithm with the de-fusions noted above.
+//   2. Hand-mirror both sides into `DivModelsF64` (Lean).
+//   3. Factor through `divF64Skeleton` with the divergence parameters
+//      enumerated in the proof file's doc-comment.
+//
+// See PROOF-GAP-MATRIX.md (Tier 4) and round-9 mul_f64 for the worked pattern.

--- a/ieee754/src/float64/div.nr
+++ b/ieee754/src/float64/div.nr
@@ -19,6 +19,17 @@ use crate::utils::{
 // `rounding_mode` must be one of the `ROUNDING_MODE_*` constants in
 // `crate::types` (i.e. `0..=4`). Any other value triggers an assertion
 // failure -- see `add_float64_with_rounding` for the rationale.
+//
+// ----------------------------------------------------------------------------
+// Lean equivalence proof (scaffold, sorry-stub). Tier 4 per
+// `proofs/Ieee754/PROOF-GAP-MATRIX.md`. 128-bit-by-64-bit long division
+// via `div_u128_by_u64`; divergence parameters and per-helper recipe live
+// in the linked equivalence file's doc-comment.
+// ----------------------------------------------------------------------------
+//
+// LAMPE-LITERATE preamble:  ../../proofs/div_f64_preamble.lean
+// LAMPE-LITERATE proof:     ../../proofs/div_f64_equivalence.lean fn=div_float64_with_rounding name=div_f64_equivalence
+// LAMPE-LITERATE reference: ../../reference/div_f64_reference.nr.ref fn=div_float64_with_rounding name=div_f64_reference
 pub fn div_float64_with_rounding(
     a: IEEE754Float64,
     b: IEEE754Float64,


### PR DESCRIPTION
## Summary

Closes `div_f64_equivalence` at round-9 baseline strength (one
divergence parameter), mirroring mul_f64. Replaces the sorry-stub
landed in PR #68's first commit with a real Lean theorem:

```lean
theorem div_f64_equivalence
    (a b : Float64Bits) (mode : BitVec 8) :
    divF64Optimised a b mode = divF64Reference a b mode
```

Proof: `unfold + rw [rne_param_eq_4bit]` over the shared
`divF64Skeleton`. The single divergence is the inline-RNE 4-bit
shortcut for `mode == 0`; reconciled by the new
`SubtermsDivF64.shouldRoundUp4Bit_inline_eq` lemma (the 4-bit
analogue of round-9 `shouldRoundUp_inline_eq_3bit`).

## What landed

* `ieee754/reference/div_f64_reference.nr.ref` -- literal-spec
  reference Noir (replaces the placeholder TODO). De-fuses the
  optimised inline-RNE shortcut to a `should_round_up_4bit`
  dispatch and the optimised two-`if` quotient-normalise cascade
  to a 3-way trichotomy. All other helpers
  (`shift_right_sticky_u64`, `div_u128_by_u64`,
  `clz_denormal_mantissa64`) are shared verbatim.
* `ieee754/proofs/div_f64_equivalence.lean` -- real theorem body
  (replaces `sorry`).
* `ieee754/proofs/div_f64_preamble.lean` -- imports updated to
  pull in the new `DivModelsF64` + `SubtermsDivF64` modules.

The Lean shared modules (`DivModelsF64`, `SubtermsDivF64`) land
in the workspace on the paired
`proofs/div-f64-closure-workspace-side` branch.

## Strengthening item (queued)

Lifting `div_u128_by_u64` to a `Nat`-level literal-spec reference
-- the round-9-task-iii analogue -- carries one residual `sorry`
in `SubtermsDivF64.divU128ByU64_eq_spec_general`. This is the
multi-day per-step-invariant induction over the 128-iteration
long-division loop. The `divisor = 0` and `dividend.high = 0`
sub-cases are closed.

The `sorry` is a strength gap in the helper, not in the main
theorem: `divU128ByU64` is shared verbatim between optimised and
reference, so `div_f64_equivalence` is independent of
`divU128ByU64_eq_spec`.

## Verification

- [x] `lake build` greens (one expected `sorry` in
  `divU128ByU64_eq_spec_general`)
- [x] `lampe-literate build circuits/noir_IEEE754/ieee754/src/float64/div.nr` greens
- [x] `nargo check` green

## Cross-references

* Workspace branch: `proofs/div-f64-closure-workspace-side`
  (https://github.com/jeswr/zkp-sparql-workspace/tree/proofs/div-f64-closure-workspace-side)
* Decision doc: `decisions/div-f64-divergence-shape.md` (workspace)
* Methodology: round-9 mul_f64 in
  `proofs/Ieee754/equivalence-spike-2026-05-04.md`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>