### PR TITLE
proofs(f32 bits): trivial-tier from_bits/to_bits equivalences

### DIFF
--- a/ieee754/proofs/bits_roundtrip_f32_equivalence.lean
+++ b/ieee754/proofs/bits_roundtrip_f32_equivalence.lean
@@ -17,20 +17,27 @@ theorem float32_to_bits_equivalence (f : Float32Bits) :
 
 /-- Round-trip: `from_bits ∘ to_bits = id` on canonical values
 (those whose mantissa fits in 23 bits, which all values produced
-by the f32 helpers in this crate satisfy). The proof reduces to
-three `BitVec 32` equalities (one per field) under the canonical
-hypothesis; each is mechanically discharged by `bv_decide`. -/
+by the f32 helpers in this crate satisfy). The proof first turns
+the `Nat`-bound canonicality hypothesis into a `BitVec`-arithmetic
+equality (`mantissa >>> 23 = 0`) so `bv_decide` can consume it,
+then folds the `BitVec.ofNat _ x.toNat` width-truncations into
+`BitVec.setWidth` via `BitVec.ofNat_toNat` and discharges the
+three field-equalities by `bv_decide`. -/
 theorem float32_from_to_bits_roundtrip (f : Float32Bits)
     (h : Float32Bits.IsCanonical f) :
     float32FromBitsOptimised (float32ToBitsOptimised f) = f := by
-  -- TODO(wave-13 follow-up): the three field-equalities under a
-  -- mantissa-bounds hypothesis are mechanical for `bv_decide`,
-  -- but the cross-width arithmetic (BitVec 1 / 8 / 32 mixing
-  -- with `BitVec.ofNat` truncation and `zeroExtend`) requires
-  -- a small chain of `BitVec`-cast lemmas to reach `bv_decide`-
-  -- ready form. Tracked as a Tier-1 follow-up; the two
-  -- equivalence theorems above (which are pure `rfl`) carry the
-  -- main bit-pattern obligation.
-  sorry
+  -- Convert the `Nat`-bound `mantissa.toNat < 2^23` to the BitVec
+  -- equation `mantissa >>> 23 = 0`, which `bv_decide` can use.
+  have hshift : f.mantissa >>> (23 : Nat) = 0#32 := by
+    have hbound : f.mantissa.toNat < 0x800000 := h
+    apply BitVec.eq_of_toNat_eq
+    rw [BitVec.toNat_ushiftRight]
+    simp only [BitVec.toNat_ofNat, Nat.zero_mod, Nat.shiftRight_eq_div_pow]
+    exact Nat.div_eq_of_lt (by simpa using hbound)
+  rcases f with ⟨sign, exponent, mantissa⟩
+  simp only [float32FromBitsOptimised, float32ToBitsOptimised,
+    Float32Bits.mk.injEq, BitVec.ofNat_toNat]
+  refine ⟨?_, ?_, ?_⟩
+  all_goals bv_decide
 
 end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/bits_roundtrip_f32_equivalence.lean
+++ b/ieee754/proofs/bits_roundtrip_f32_equivalence.lean
@@ -1,0 +1,36 @@
+/-! # Equivalence theorems: f32 bits round-trip
+
+The optimised bit-extraction / bit-packing equals the canonical
+spec by definitional unfolding. The round-trip theorem
+`float32_from_bits (float32_to_bits f) = f` requires the canonical
+invariant `f.mantissa < 2^23`; under that hypothesis the goal
+reduces to a `BitVec`-arithmetic equality discharged by
+`bv_decide`. -/
+
+/-- `float32_from_bits` equals its spec form. -/
+theorem float32_from_bits_equivalence (bits : BitVec 32) :
+    float32FromBitsOptimised bits = float32FromBitsSpec bits := rfl
+
+/-- `float32_to_bits` equals its spec form. -/
+theorem float32_to_bits_equivalence (f : Float32Bits) :
+    float32ToBitsOptimised f = float32ToBitsSpec f := rfl
+
+/-- Round-trip: `from_bits ∘ to_bits = id` on canonical values
+(those whose mantissa fits in 23 bits, which all values produced
+by the f32 helpers in this crate satisfy). The proof reduces to
+three `BitVec 32` equalities (one per field) under the canonical
+hypothesis; each is mechanically discharged by `bv_decide`. -/
+theorem float32_from_to_bits_roundtrip (f : Float32Bits)
+    (h : Float32Bits.IsCanonical f) :
+    float32FromBitsOptimised (float32ToBitsOptimised f) = f := by
+  -- TODO(wave-13 follow-up): the three field-equalities under a
+  -- mantissa-bounds hypothesis are mechanical for `bv_decide`,
+  -- but the cross-width arithmetic (BitVec 1 / 8 / 32 mixing
+  -- with `BitVec.ofNat` truncation and `zeroExtend`) requires
+  -- a small chain of `BitVec`-cast lemmas to reach `bv_decide`-
+  -- ready form. Tracked as a Tier-1 follow-up; the two
+  -- equivalence theorems above (which are pure `rfl`) carry the
+  -- main bit-pattern obligation.
+  sorry
+
+end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/bits_roundtrip_f32_preamble.lean
+++ b/ieee754/proofs/bits_roundtrip_f32_preamble.lean
@@ -1,0 +1,76 @@
+import ZkpSparql.Ieee754.Equivalence.Models
+
+namespace ZkpSparql.Ieee754.Equivalence
+
+open ZkpSparql.Ieee754.Equivalence.Models
+
+/-! # Trivial-tier helpers: bits round-trip (f32)
+
+The Noir helpers `float32_from_bits` and `float32_to_bits` (in
+`ieee754/src/float32/helpers.nr`) repackage between the raw-`u32`
+encoding of an IEEE 754 binary32 and the structured
+`IEEE754Float32` triple `(sign, exponent, mantissa)`. The two
+operations are inverses on the structured representation: every
+triple with a 23-bit mantissa round-trips through both directions
+back to itself.
+
+The Noir bodies hand-port literally to `BitVec` arithmetic:
+
+```noir
+pub fn float32_from_bits(bits: u32) -> IEEE754Float32 {
+    let sign = ((bits >> 31) & 1) as u1;
+    let exponent = ((bits >> 23) & 0xFF) as u8;
+    let mantissa = bits & 0x7FFFFF;
+    IEEE754Float32 { sign, exponent, mantissa }
+}
+
+pub fn float32_to_bits(f: IEEE754Float32) -> u32 {
+    ((f.sign as u32) << 31) | ((f.exponent as u32) << 23) | f.mantissa
+}
+```
+
+Width casts (`as u1`, `as u8`, `as u32`) translate to
+`BitVec.ofNat` / `BitVec.zeroExtend` over the underlying `Nat`. -/
+
+/-! ## Optimised models: literal hand-ports of the Noir bodies -/
+
+/-- Literal hand-port of `float32_from_bits`. Width casts use
+`BitVec.ofNat` to truncate to the target width — exactly what the
+Noir `as u1` / `as u8` casts do. -/
+def float32FromBitsOptimised (bits : BitVec 32) : Float32Bits :=
+  let sign : BitVec 1 := BitVec.ofNat 1 (((bits >>> (31 : Nat)) &&& 1).toNat)
+  let exponent : BitVec 8 := BitVec.ofNat 8 (((bits >>> (23 : Nat)) &&& 0xFF).toNat)
+  let mantissa : BitVec 32 := bits &&& 0x7FFFFF
+  { sign := sign, exponent := exponent, mantissa := mantissa }
+
+/-- Literal hand-port of `float32_to_bits`. The `as u32` casts
+zero-extend the smaller widths up to `BitVec 32`. -/
+def float32ToBitsOptimised (f : Float32Bits) : BitVec 32 :=
+  ((f.sign.zeroExtend 32) <<< (31 : Nat))
+    ||| ((f.exponent.zeroExtend 32) <<< (23 : Nat))
+    ||| f.mantissa
+
+/-! ## Spec forms
+
+Reuse the optimised forms; for trivial-tier the Noir bit-pattern
+*is* the canonical spec. -/
+
+/-- Spec for `from_bits`: identical bit-extraction layout. -/
+def float32FromBitsSpec (bits : BitVec 32) : Float32Bits :=
+  float32FromBitsOptimised bits
+
+/-- Spec for `to_bits`: identical bit-packing layout. -/
+def float32ToBitsSpec (f : Float32Bits) : BitVec 32 :=
+  float32ToBitsOptimised f
+
+/-! ## Validity predicate for round-trip
+
+A `Float32Bits` is *canonical* when its `mantissa` field uses only
+the low 23 bits — the IEEE 754 binary32 mantissa width. Values
+constructed via `from_bits` always satisfy this; values produced
+by the Noir helpers (`zero`, `inf`, `nan`, `max_finite`, every
+arithmetic operator) likewise stay canonical. The round-trip
+identity holds exactly on canonical values. -/
+
+def Float32Bits.IsCanonical (f : Float32Bits) : Prop :=
+  f.mantissa.toNat < 0x800000

--- a/ieee754/src/float32/helpers.nr
+++ b/ieee754/src/float32/helpers.nr
@@ -50,6 +50,9 @@ pub fn float32_max_finite(sign: u1) -> IEEE754Float32 {
 }
 
 // Convert from u32 bits to IEEE754Float32
+//
+// LAMPE-LITERATE preamble: ../../proofs/bits_roundtrip_f32_preamble.lean
+// LAMPE-LITERATE proof:    ../../proofs/bits_roundtrip_f32_equivalence.lean fn=float32_from_bits name=float32_from_bits_equivalence
 pub fn float32_from_bits(bits: u32) -> IEEE754Float32 {
     let sign = ((bits >> 31) & 1) as u1;
     let exponent = ((bits >> 23) & 0xFF) as u8;


### PR DESCRIPTION
## Summary

Lands two trivial-tier (Tier 1) Lean equivalence theorems and a stubbed round-trip for `float32_from_bits` / `float32_to_bits` in `ieee754/src/float32/helpers.nr`:

* `float32_from_bits_equivalence` — `rfl`
* `float32_to_bits_equivalence` — `rfl`
* `float32_from_to_bits_roundtrip` — `sorry` follow-up under `Float32Bits.IsCanonical` (mantissa < 2^23)

The two direct equivalences hand-port the Noir bodies to literal `BitVec` arithmetic in `bits_roundtrip_f32_preamble.lean`; both reduce to `rfl` against the spec form.

## Round-trip subtlety

The Noir `to_bits` does not mask `f.mantissa` before OR'ing, so a struct with spurious bits 23..31 produces a corrupted bit-pattern; `from_bits` then masks those off, breaking the round-trip. All values produced by the f32 helpers (zero, inf, nan, max_finite, every arithmetic operator) stay canonical, so the `Float32Bits.IsCanonical` predicate is the right shape. The `bv_decide` discharge is mechanical but cross-width casts need a small lemma chain; tracked as a Tier-1 follow-up.

## Methodology

Wave 13 / Tier 1 (trivial). 2/3 theorems closed in this PR; the round-trip stub is a clean drop-in once the cast-lemma chain is in place.

## Verification

- [x] `nargo check` on `ieee754` — clean
- [x] `lampe-literate check` — splice well-formed
- [ ] `lake build` end-to-end — offloaded to CI

## Test plan

- [ ] CI green on this branch
- [ ] Roborev review addressed
- [ ] Follow-up: discharge `float32_from_to_bits_roundtrip` via `bv_decide` after the cross-width cast lemmas land