### PR TITLE
proofs(f64 bits): trivial-tier from_bits/to_bits equivalences

### DIFF
--- a/ieee754/proofs/bits_roundtrip_f64_equivalence.lean
+++ b/ieee754/proofs/bits_roundtrip_f64_equivalence.lean
@@ -13,14 +13,31 @@ theorem float64_to_bits_equivalence (f : Float64Bits) :
     float64ToBitsOptimised f = float64ToBitsSpec f := rfl
 
 /-- Round-trip: `from_bits ∘ to_bits = id` on canonical values
-(those whose mantissa fits in 52 bits). -/
+(those whose mantissa fits in 52 bits and whose biased exponent
+fits in 11 bits). The proof mirrors the f32 closure: convert the
+two `Nat`-bounds in the canonicality hypothesis to BitVec
+shift-equations (`mantissa >>> 52 = 0` and `exponent >>> 11 = 0`),
+fold the `BitVec.ofNat _ x.toNat` width-truncations via
+`BitVec.ofNat_toNat`, and discharge the three field-equalities
+with `bv_decide`. -/
 theorem float64_from_to_bits_roundtrip (f : Float64Bits)
     (h : Float64Bits.IsCanonical f) :
     float64FromBitsOptimised (float64ToBitsOptimised f) = f := by
-  -- TODO(wave-13 follow-up): three field-equalities under a
-  -- mantissa-bounds hypothesis; mechanical for `bv_decide` once
-  -- the cross-width cast lemmas are in place. Same shape as the
-  -- f32 stub.
-  sorry
+  obtain ⟨hmant, hexp⟩ := h
+  have hmshift : f.mantissa >>> (52 : Nat) = 0#64 := by
+    apply BitVec.eq_of_toNat_eq
+    rw [BitVec.toNat_ushiftRight]
+    simp only [BitVec.toNat_ofNat, Nat.zero_mod, Nat.shiftRight_eq_div_pow]
+    exact Nat.div_eq_of_lt (by simpa using hmant)
+  have heshift : f.exponent >>> (11 : Nat) = 0#16 := by
+    apply BitVec.eq_of_toNat_eq
+    rw [BitVec.toNat_ushiftRight]
+    simp only [BitVec.toNat_ofNat, Nat.zero_mod, Nat.shiftRight_eq_div_pow]
+    exact Nat.div_eq_of_lt (by simpa using hexp)
+  rcases f with ⟨sign, exponent, mantissa⟩
+  simp only [float64FromBitsOptimised, float64ToBitsOptimised,
+    Float64Bits.mk.injEq, BitVec.ofNat_toNat]
+  refine ⟨?_, ?_, ?_⟩
+  all_goals bv_decide
 
 end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/bits_roundtrip_f64_equivalence.lean
+++ b/ieee754/proofs/bits_roundtrip_f64_equivalence.lean
@@ -1,0 +1,26 @@
+/-! # Equivalence theorems: f64 bits round-trip
+
+Mirrors the f32 round-trip story for binary64. The two direct
+equivalences reduce to `rfl`; the round-trip identity holds on
+canonical values (mantissa < 2^52). -/
+
+/-- `float64_from_bits` equals its spec form. -/
+theorem float64_from_bits_equivalence (bits : BitVec 64) :
+    float64FromBitsOptimised bits = float64FromBitsSpec bits := rfl
+
+/-- `float64_to_bits` equals its spec form. -/
+theorem float64_to_bits_equivalence (f : Float64Bits) :
+    float64ToBitsOptimised f = float64ToBitsSpec f := rfl
+
+/-- Round-trip: `from_bits ∘ to_bits = id` on canonical values
+(those whose mantissa fits in 52 bits). -/
+theorem float64_from_to_bits_roundtrip (f : Float64Bits)
+    (h : Float64Bits.IsCanonical f) :
+    float64FromBitsOptimised (float64ToBitsOptimised f) = f := by
+  -- TODO(wave-13 follow-up): three field-equalities under a
+  -- mantissa-bounds hypothesis; mechanical for `bv_decide` once
+  -- the cross-width cast lemmas are in place. Same shape as the
+  -- f32 stub.
+  sorry
+
+end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/bits_roundtrip_f64_preamble.lean
+++ b/ieee754/proofs/bits_roundtrip_f64_preamble.lean
@@ -63,7 +63,12 @@ def float64ToBitsSpec (f : Float64Bits) : BitVec 64 :=
 /-! ## Validity predicate for round-trip
 
 A `Float64Bits` is *canonical* when its `mantissa` field uses only
-the low 52 bits — the IEEE 754 binary64 mantissa width. -/
+the low 52 bits and its `exponent` field uses only the low 11 bits
+— the IEEE 754 binary64 mantissa / biased-exponent widths. The
+Lean record is wider than IEEE 754 specifies (`mantissa : BitVec
+64`, `exponent : BitVec 16`); without these bounds the
+hypothetical high bits would survive `from_bits ∘ to_bits` only if
+the `to_bits` shifts truncated them, which they do not. -/
 
 def Float64Bits.IsCanonical (f : Float64Bits) : Prop :=
-  f.mantissa.toNat < 0x10000000000000
+  f.mantissa.toNat < 0x10000000000000 ∧ f.exponent.toNat < 0x800

--- a/ieee754/proofs/bits_roundtrip_f64_preamble.lean
+++ b/ieee754/proofs/bits_roundtrip_f64_preamble.lean
@@ -1,0 +1,69 @@
+import ZkpSparql.Ieee754.Equivalence.ModelsF64
+
+namespace ZkpSparql.Ieee754.Equivalence
+
+open ZkpSparql.Ieee754.Equivalence.ModelsF64
+
+/-! # Trivial-tier helpers: bits round-trip (f64)
+
+The Noir helpers `float64_from_bits` and `float64_to_bits` (in
+`ieee754/src/float64/helpers.nr`) repackage between the raw-`u64`
+encoding of an IEEE 754 binary64 and the structured
+`IEEE754Float64` triple `(sign, exponent, mantissa)`. The two
+operations are inverses on canonical structured values (those
+whose mantissa fits in 52 bits).
+
+The Noir bodies hand-port literally to `BitVec` arithmetic:
+
+```noir
+pub fn float64_from_bits(bits: u64) -> IEEE754Float64 {
+    let sign = ((bits >> 63) & 1) as u1;
+    let exponent = ((bits >> 52) & 0x7FF) as u16;
+    let mantissa = bits & 0xFFFFFFFFFFFFF;
+    IEEE754Float64 { sign, exponent, mantissa }
+}
+
+pub fn float64_to_bits(f: IEEE754Float64) -> u64 {
+    ((f.sign as u64) << 63) | ((f.exponent as u64) << 52) | f.mantissa
+}
+```
+-/
+
+/-! ## Optimised models: literal hand-ports of the Noir bodies -/
+
+/-- Literal hand-port of `float64_from_bits`. Width casts use
+`BitVec.ofNat` to truncate to the target width — exactly what the
+Noir `as u1` / `as u16` casts do. -/
+def float64FromBitsOptimised (bits : BitVec 64) : Float64Bits :=
+  let sign : BitVec 1 := BitVec.ofNat 1 (((bits >>> (63 : Nat)) &&& 1).toNat)
+  let exponent : BitVec 16 := BitVec.ofNat 16 (((bits >>> (52 : Nat)) &&& 0x7FF).toNat)
+  let mantissa : BitVec 64 := bits &&& 0xFFFFFFFFFFFFF
+  { sign := sign, exponent := exponent, mantissa := mantissa }
+
+/-- Literal hand-port of `float64_to_bits`. The `as u64` casts
+zero-extend the smaller widths up to `BitVec 64`. -/
+def float64ToBitsOptimised (f : Float64Bits) : BitVec 64 :=
+  ((f.sign.zeroExtend 64) <<< (63 : Nat))
+    ||| ((f.exponent.zeroExtend 64) <<< (52 : Nat))
+    ||| f.mantissa
+
+/-! ## Spec forms
+
+Reuse the optimised forms; for trivial-tier the Noir bit-pattern
+*is* the canonical spec. -/
+
+/-- Spec for `from_bits`: identical bit-extraction layout. -/
+def float64FromBitsSpec (bits : BitVec 64) : Float64Bits :=
+  float64FromBitsOptimised bits
+
+/-- Spec for `to_bits`: identical bit-packing layout. -/
+def float64ToBitsSpec (f : Float64Bits) : BitVec 64 :=
+  float64ToBitsOptimised f
+
+/-! ## Validity predicate for round-trip
+
+A `Float64Bits` is *canonical* when its `mantissa` field uses only
+the low 52 bits — the IEEE 754 binary64 mantissa width. -/
+
+def Float64Bits.IsCanonical (f : Float64Bits) : Prop :=
+  f.mantissa.toNat < 0x10000000000000

--- a/ieee754/src/float64/helpers.nr
+++ b/ieee754/src/float64/helpers.nr
@@ -47,6 +47,9 @@ pub fn float64_max_finite(sign: u1) -> IEEE754Float64 {
 }
 
 // Convert from u64 bits to IEEE754Float64
+//
+// LAMPE-LITERATE preamble: ../../proofs/bits_roundtrip_f64_preamble.lean
+// LAMPE-LITERATE proof:    ../../proofs/bits_roundtrip_f64_equivalence.lean fn=float64_from_bits name=float64_from_bits_equivalence
 pub fn float64_from_bits(bits: u64) -> IEEE754Float64 {
     let sign = ((bits >> 63) & 1) as u1;
     let exponent = ((bits >> 52) & 0x7FF) as u16;


### PR DESCRIPTION
## Summary

Lands two trivial-tier (Tier 1) Lean equivalence theorems and a stubbed round-trip for `float64_from_bits` / `float64_to_bits` in `ieee754/src/float64/helpers.nr`:

* `float64_from_bits_equivalence` — `rfl`
* `float64_to_bits_equivalence` — `rfl`
* `float64_from_to_bits_roundtrip` — `sorry` follow-up under `Float64Bits.IsCanonical` (mantissa < 2^52)

Mirrors the f32-bits PR (#70), swapped to the binary64 layout (63-bit sign shift, 52-bit exponent shift, 52-bit mantissa mask `0xFFFFFFFFFFFFF`).

## Methodology

Wave 13 / Tier 1 (trivial). 2/3 theorems closed. Round-trip stub lifts mechanically once the cross-width cast lemma chain is in place.

## Verification

- [x] `nargo check` on `ieee754` — clean
- [x] `lampe-literate check` — splice well-formed
- [ ] `lake build` end-to-end — offloaded to CI

## Test plan

- [ ] CI green on this branch
- [ ] Roborev review addressed
- [ ] Follow-up: discharge `float64_from_to_bits_roundtrip` via `bv_decide`