### PR TITLE
proofs(abs): trivial-tier equivalences for abs_float32 + abs_float64

### DIFF
--- a/ieee754/proofs/abs_equivalence.lean
+++ b/ieee754/proofs/abs_equivalence.lean
@@ -1,0 +1,12 @@
+/-! # Equivalence theorems: f32 + f64 abs
+
+Both sides are the same `Float<W>Bits` struct expression after
+unfolding, so `rfl` closes each goal. -/
+
+theorem abs_float32_equivalence (a : Float32Bits) :
+    absFloat32Optimised a = absFloat32Spec a := rfl
+
+theorem abs_float64_equivalence (a : Float64Bits) :
+    absFloat64Optimised a = absFloat64Spec a := rfl
+
+end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/abs_preamble.lean
+++ b/ieee754/proofs/abs_preamble.lean
@@ -1,0 +1,38 @@
+import ZkpSparql.Ieee754.Equivalence.Models
+import ZkpSparql.Ieee754.Equivalence.ModelsF64
+
+namespace ZkpSparql.Ieee754.Equivalence
+
+open ZkpSparql.Ieee754.Equivalence.Models
+open ZkpSparql.Ieee754.Equivalence.ModelsF64
+
+/-! # Trivial-tier helpers: absolute value (f32 + f64)
+
+The Noir helpers `abs_float32` and `abs_float64` (in
+`ieee754/src/float{32,64}/mod.nr`) clear the sign bit by
+constructing a fresh struct with `sign := 0` and the original
+`exponent` / `mantissa`. The IEEE 754-2019 sec 5.5.1 abs operation
+is exactly this: a sign-bit clear, applied uniformly to all
+encodings (so `abs(-NaN)` is `+NaN`, `abs(-0)` is `+0`, etc.).
+Each equivalence theorem reduces to `rfl`. -/
+
+/-! ## Optimised models: literal hand-ports of the Noir bodies -/
+
+/-- Literal hand-port of `abs_float32`. -/
+def absFloat32Optimised (a : Float32Bits) : Float32Bits :=
+  { sign := 0, exponent := a.exponent, mantissa := a.mantissa }
+
+/-- Literal hand-port of `abs_float64`. -/
+def absFloat64Optimised (a : Float64Bits) : Float64Bits :=
+  { sign := 0, exponent := a.exponent, mantissa := a.mantissa }
+
+/-! ## Spec forms — sign-bit clear
+
+The IEEE 754-2019 sec 5.5.1 spec is "set the sign bit to zero".
+Both spec and optimised forms are the same struct expression. -/
+
+def absFloat32Spec (a : Float32Bits) : Float32Bits :=
+  { sign := 0, exponent := a.exponent, mantissa := a.mantissa }
+
+def absFloat64Spec (a : Float64Bits) : Float64Bits :=
+  { sign := 0, exponent := a.exponent, mantissa := a.mantissa }

--- a/ieee754/src/float32/mod.nr
+++ b/ieee754/src/float32/mod.nr
@@ -53,6 +53,9 @@ pub fn sub_float32(a: IEEE754Float32, b: IEEE754Float32) -> IEEE754Float32 {
 // IEEE 754 compliant absolute value for 32-bit floats
 // Returns the magnitude of the float (sign bit set to 0)
 // Note: abs(NaN) returns NaN (with sign bit cleared)
+//
+// LAMPE-LITERATE preamble: ../../proofs/abs_preamble.lean
+// LAMPE-LITERATE proof:    ../../proofs/abs_equivalence.lean fn=abs_float32 name=abs_float32_equivalence
 pub fn abs_float32(a: IEEE754Float32) -> IEEE754Float32 {
     IEEE754Float32 { sign: 0, exponent: a.exponent, mantissa: a.mantissa }
 }

--- a/ieee754/src/float64/mod.nr
+++ b/ieee754/src/float64/mod.nr
@@ -53,6 +53,9 @@ pub fn sub_float64(a: IEEE754Float64, b: IEEE754Float64) -> IEEE754Float64 {
 // IEEE 754 compliant absolute value for 64-bit floats
 // Returns the magnitude of the float (sign bit set to 0)
 // Note: abs(NaN) returns NaN (with sign bit cleared)
+//
+// LAMPE-LITERATE preamble: ../../proofs/abs_preamble.lean
+// LAMPE-LITERATE proof:    ../../proofs/abs_equivalence.lean fn=abs_float64 name=abs_float64_equivalence
 pub fn abs_float64(a: IEEE754Float64) -> IEEE754Float64 {
     IEEE754Float64 { sign: 0, exponent: a.exponent, mantissa: a.mantissa }
 }


### PR DESCRIPTION
## Summary

Lands two trivial-tier (Tier 1) Lean equivalence theorems for the IEEE 754 absolute-value helpers in `ieee754/src/float{32,64}/mod.nr`:

* `abs_float32_equivalence`
* `abs_float64_equivalence`

Both Noir helpers clear the sign bit by constructing a fresh struct with `sign := 0` and the original exponent / mantissa. The optimised hand-port and the canonical IEEE 754-2019 sec 5.5.1 sign-bit-clear spec are the same struct expression; each theorem reduces to `rfl`.

## Methodology

Wave 13 / Tier 1 (trivial). Tiny PR — two theorems, one shared preamble + proof file pair referenced from both `float32/mod.nr` and `float64/mod.nr` directive lines. The `lampe-literate` build materialises both `Generated.lean` files independently; both theorems land regardless of which source `lampe-literate build` is invoked on.

## Verification

- [x] `nargo check` on `ieee754` — clean
- [x] `lampe-literate check ieee754/src/float32/mod.nr` — splice well-formed
- [x] `lampe-literate check ieee754/src/float64/mod.nr` — splice well-formed
- [ ] `lake build` end-to-end — offloaded to CI

## Test plan

- [ ] CI green on this branch
- [ ] Roborev review addressed