### PR TITLE
feat(proofs): migrate round-7a sub_f32_equivalence to lampe-literate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ noir/lib/*/lampe/
 # module and the cached lake build. Regenerated from the literate Noir
 # directive lines each time `lampe-literate build` runs; never edited
 # by hand.
+# lampe-literate scratch dir (per-source). Contains the Lampe-extracted
+# Lean, the spliced proof module, and the cached lake build. Regenerated
+# from the literate Noir comment blocks each time `lampe-literate build`
+# runs; never edited by hand.
 **/.lampe-literate/
 
 # Node.js / semantic-release

--- a/ieee754/proofs/sub_f32_equivalence.lean
+++ b/ieee754/proofs/sub_f32_equivalence.lean
@@ -1,0 +1,125 @@
+/-! ## Round-6 dependency: `add_f32_equivalence`
+
+The round-7 `sub_f32_equivalence` reduces mechanically to round-6's
+`add_f32_equivalence` applied to `(a, negateF32 b, mode)` (IEEE
+754-2019 §6.3). The round-6 closure body is inlined here so this
+splice (`circuits/noir_IEEE754/ieee754/src/float32/mod.nr`) is
+self-contained and does not have to reach into the splice tree
+generated for `add.nr`. The two splices live in separate scratch
+trees, so the duplication never produces a name collision at
+build time. -/
+
+/-- The optimised path's inlined round-to-nearest-even computation
+is the body of `shouldRoundUp` for `mode = 0`. -/
+theorem shouldRoundUp_inline_eq
+    (guardBits : BitVec 64) (resultMant : BitVec 64)
+    (resultSign : BitVec 1) :
+    shouldRoundUp guardBits resultMant resultSign 0
+      = (decide (guardBits.toNat > 4)
+          || (decide (guardBits = 4) && decide (resultMant &&& 1 = 1))) := by
+  unfold shouldRoundUp
+  simp [modeNearestEven]
+
+private theorem clz_param_eq : clzBinary = clzLoop := by
+  funext v; exact (clz_eq v).symm
+
+private theorem rne_param_eq :
+    (fun (gb : BitVec 64) (rm : BitVec 64) (rs : BitVec 1) (m : BitVec 8) =>
+      if m = 0 then
+        decide (gb.toNat > 4) ||
+          (decide (gb = 4) && decide (rm &&& 1 = 1))
+      else
+        shouldRoundUp gb rm rs m) = shouldRoundUp := by
+  funext gb rm rs m
+  by_cases hmode : m = 0
+  · subst hmode
+    rw [if_pos rfl]
+    exact (shouldRoundUp_inline_eq gb rm rs).symm
+  · rw [if_neg hmode]
+
+private theorem align_eq (a b : Float32Bits) :
+    alignF32Optimised a b = alignF32Reference a b := by
+  unfold alignF32Optimised alignF32Reference
+  set expA : BitVec 64 := effectiveExp a with hExpA
+  set expB : BitVec 64 := effectiveExp b with hExpB
+  rcases lt_trichotomy expA.toNat expB.toNat with hlt | heq | hgt
+  · have hngeA : ¬ expA.toNat ≥ expB.toNat := by omega
+    have hngtA : ¬ expA.toNat > expB.toNat := by omega
+    have hgtB : expB.toNat > expA.toNat := hlt
+    have hshift_ne : (expB - expA).toNat ≠ 0 := by
+      rw [BitVec.toNat_sub]
+      have hb_lt : expB.toNat < 18446744073709551616 := BitVec.isLt _
+      have ha_lt : expA.toNat < 18446744073709551616 := BitVec.isLt _
+      omega
+    simp only [Id.run, hngeA, hngtA, hgtB, if_true, if_false,
+               ge_iff_le, Nat.not_le_of_lt, shr_sticky_eq _ _ hshift_ne]
+    rfl
+  · have hsub : expA - expB = 0 := by
+      apply BitVec.eq_of_toNat_eq
+      rw [BitVec.toNat_sub, heq]
+      have hbound : expB.toNat ≤ 18446744073709551616 :=
+        Nat.le_of_lt (BitVec.isLt _)
+      change _ = (0 : BitVec 64).toNat
+      simp; omega
+    have hsub' : expB - expA = 0 := by
+      apply BitVec.eq_of_toNat_eq
+      rw [BitVec.toNat_sub, ← heq]
+      have hbound : expA.toNat ≤ 18446744073709551616 :=
+        Nat.le_of_lt (BitVec.isLt _)
+      change _ = (0 : BitVec 64).toNat
+      simp; omega
+    have hge : expA.toNat ≥ expB.toNat := Nat.le_of_eq heq.symm
+    have hngtA : ¬ expA.toNat > expB.toNat := by omega
+    have hngtB : ¬ expB.toNat > expA.toNat := by omega
+    have hexp_eq : expA = expB := by
+      apply BitVec.eq_of_toNat_eq; exact heq
+    simp only [Id.run, hngtA, hngtB, hge, ge_iff_le, hsub, hsub',
+               shrStickyHelper_zero, if_true, if_false]
+    rfl
+  · have hge : expA.toNat ≥ expB.toNat := Nat.le_of_lt hgt
+    have hngtB : ¬ expB.toNat > expA.toNat := by omega
+    have hshift_ne : (expA - expB).toNat ≠ 0 := by
+      rw [BitVec.toNat_sub]
+      have hb_lt : expB.toNat < 18446744073709551616 := BitVec.isLt _
+      have ha_lt : expA.toNat < 18446744073709551616 := BitVec.isLt _
+      omega
+    simp only [Id.run, hgt, hngtB, hge, ge_iff_le, if_true, if_false,
+               shr_sticky_eq _ _ hshift_ne]
+    rfl
+
+theorem add_f32_equivalence
+    (a b : Float32Bits) (mode : BitVec 8) :
+    addF32Optimised a b mode = addF32Reference a b mode := by
+  unfold addF32Optimised addF32Reference
+  rw [align_eq a b, clz_param_eq, rne_param_eq]
+
+/-! ## Round-7a: sub equivalence
+
+IEEE 754-2019 §6.3 mandates `subtract(a, b) = add(a, negate(b))`.
+Both the optimised circuit and the reference take that definition
+literally, so the equivalence reduces to `add_f32_equivalence`. -/
+
+/-- Flip the sign bit of a `Float32Bits`. Mirrors the Noir
+construction `IEEE754Float32 { sign = 1 - b.sign, exponent =
+b.exponent, mantissa = b.mantissa }` from
+`ieee754::float32::sub_float32_with_rounding`. -/
+def negateF32 (b : Float32Bits) : Float32Bits :=
+  { sign := 1 - b.sign, exponent := b.exponent, mantissa := b.mantissa }
+
+/-- Line-by-line transcription of `sub_float32_with_rounding`. -/
+def subF32Optimised (a b : Float32Bits) (mode : BitVec 8) : Float32Bits :=
+  addF32Optimised a (negateF32 b) mode
+
+/-- Reference: subtraction = `add(a, negate(b))`. -/
+def subF32Reference (a b : Float32Bits) (mode : BitVec 8) : Float32Bits :=
+  addF32Reference a (negateF32 b) mode
+
+/-- The optimised f32 sub is bit-identical to the literal-IEEE-754
+reference f32 sub, for every input and every rounding mode. -/
+theorem sub_f32_equivalence
+    (a b : Float32Bits) (mode : BitVec 8) :
+    subF32Optimised a b mode = subF32Reference a b mode := by
+  unfold subF32Optimised subF32Reference
+  exact add_f32_equivalence a (negateF32 b) mode
+
+end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/sub_f32_equivalence.lean
+++ b/ieee754/proofs/sub_f32_equivalence.lean
@@ -1,3 +1,17 @@
+/-! # Lampe-literate splice fragment — sub_f32 equivalence
+
+This file is **not** a standalone Lean module. It is a literate
+splice fragment consumed by `circuits/lampe-literate`: the build
+tool concatenates `sub_f32_preamble.lean` (which opens the
+`ZkpSparql.Ieee754.Equivalence` namespace) with this body into a
+generated module under the gitignored `.lampe-literate/` scratch
+tree, matching the `LAMPE-LITERATE` directives in
+`../src/float32/mod.nr`. The terminating `end
+ZkpSparql.Ieee754.Equivalence` below balances the namespace
+**after** splicing, not in this fragment in isolation. Editor /
+linter errors from opening this file directly are expected; build
+it via `lampe-literate build`. -/
+
 /-! ## Round-6 dependency: `add_f32_equivalence`
 
 The round-7 `sub_f32_equivalence` reduces mechanically to round-6's
@@ -87,7 +101,14 @@ private theorem align_eq (a b : Float32Bits) :
                shr_sticky_eq _ _ hshift_ne]
     rfl
 
-theorem add_f32_equivalence
+/-- Inlined round-6 add equivalence — kept `private` to this
+splice module so it does not become part of the published API
+surface alongside the round-7a `sub_f32_equivalence` theorem this
+file is named for. The canonical public-facing
+`add_f32_equivalence` lives in the round-6 splice tree
+(`add.nr` -> `add_f32_equivalence.lean`); this copy exists solely
+because the splice trees are disjoint. -/
+private theorem add_f32_equivalence
     (a b : Float32Bits) (mode : BitVec 8) :
     addF32Optimised a b mode = addF32Reference a b mode := by
   unfold addF32Optimised addF32Reference

--- a/ieee754/proofs/sub_f32_preamble.lean
+++ b/ieee754/proofs/sub_f32_preamble.lean
@@ -1,3 +1,16 @@
+-- # Lampe-literate splice fragment - sub_f32 preamble
+--
+-- This file is **not** a standalone Lean module. It is a literate
+-- splice fragment consumed by `circuits/lampe-literate`: the build
+-- tool concatenates this preamble with `sub_f32_equivalence.lean`
+-- (matching the `LAMPE-LITERATE preamble:` / `proof:` directives in
+-- `../src/float32/mod.nr`) into a generated module under the
+-- gitignored `.lampe-literate/` scratch tree. The companion fragment
+-- emits the matching `end ZkpSparql.Ieee754.Equivalence` so the
+-- namespace balances **after** splicing, not in either fragment in
+-- isolation. Editor / linter errors from opening this file directly
+-- are expected; build it via `lampe-literate build`.
+
 import ZkpSparql.Ieee754.Equivalence.Models
 import ZkpSparql.Ieee754.Equivalence.Subterms
 

--- a/ieee754/proofs/sub_f32_preamble.lean
+++ b/ieee754/proofs/sub_f32_preamble.lean
@@ -1,0 +1,7 @@
+import ZkpSparql.Ieee754.Equivalence.Models
+import ZkpSparql.Ieee754.Equivalence.Subterms
+
+namespace ZkpSparql.Ieee754.Equivalence
+
+open ZkpSparql.Ieee754.Equivalence.Models
+open ZkpSparql.Ieee754.Equivalence.Subterms

--- a/ieee754/src/float32/mod.nr
+++ b/ieee754/src/float32/mod.nr
@@ -33,7 +33,22 @@ pub use sqrt::{sqrt_float32, sqrt_float32_with_rounding};
 use crate::types::{IEEE754Float32, ROUNDING_MODE_NEAREST_EVEN};
 
 // IEEE 754 compliant subtraction for 32-bit floats with rounding mode
-// Implemented as a + (-b)
+// Implemented as a + (-b).
+//
+// ----------------------------------------------------------------------------
+// Lean equivalence proof (round 7a). See `circuits/lampe-literate` for the
+// build tool that resolves the LAMPE-LITERATE directives below, splices the
+// referenced proof file into a generated Lean module, and runs `lake build`
+// against the workspace's shared `Models.lean` / `Subterms.lean`. Generated
+// `.lean` files land in a gitignored scratch dir; only this Noir source plus
+// the standalone `.lean` proof files are version-controlled. The proof file
+// inlines round-6 `add_f32_equivalence` because IEEE 754-2019 sec 6.3
+// reduces sub to add(a, negate(b)); the splice tree for this `.nr` is
+// disjoint from `add.nr`'s, so the duplication never collides.
+// ----------------------------------------------------------------------------
+//
+// LAMPE-LITERATE preamble: ../../proofs/sub_f32_preamble.lean
+// LAMPE-LITERATE proof:    ../../proofs/sub_f32_equivalence.lean fn=sub_float32_with_rounding name=sub_f32_equivalence
 pub fn sub_float32_with_rounding(
     a: IEEE754Float32,
     b: IEEE754Float32,

--- a/ieee754/src/float32/mod.nr
+++ b/ieee754/src/float32/mod.nr
@@ -38,13 +38,17 @@ use crate::types::{IEEE754Float32, ROUNDING_MODE_NEAREST_EVEN};
 // ----------------------------------------------------------------------------
 // Lean equivalence proof (round 7a). See `circuits/lampe-literate` for the
 // build tool that resolves the LAMPE-LITERATE directives below, splices the
-// referenced proof file into a generated Lean module, and runs `lake build`
-// against the workspace's shared `Models.lean` / `Subterms.lean`. Generated
-// `.lean` files land in a gitignored scratch dir; only this Noir source plus
-// the standalone `.lean` proof files are version-controlled. The proof file
-// inlines round-6 `add_f32_equivalence` because IEEE 754-2019 sec 6.3
-// reduces sub to add(a, negate(b)); the splice tree for this `.nr` is
-// disjoint from `add.nr`'s, so the duplication never collides.
+// referenced proof fragments into a generated Lean module, and runs `lake
+// build` against the workspace's shared `Models.lean` / `Subterms.lean`.
+// Generated `.lean` files land in a gitignored scratch dir; only this Noir
+// source plus the literate splice-fragment `.lean` files are version-
+// controlled. Note: the `.lean` files referenced below are splice fragments,
+// not standalone Lean modules -- the namespace opens in the preamble fragment
+// and closes in the equivalence fragment, so each file is invalid in
+// isolation but balances after the build tool concatenates them. The proof
+// fragment inlines round-6 `add_f32_equivalence` (as `private`) because IEEE
+// 754-2019 sec 6.3 reduces sub to add(a, negate(b)); the splice tree for
+// this `.nr` is disjoint from `add.nr`'s, so the duplication never collides.
 // ----------------------------------------------------------------------------
 //
 // LAMPE-LITERATE preamble: ../../proofs/sub_f32_preamble.lean


### PR DESCRIPTION
## Summary

Migrates the round-7 f32-sub equivalence proof out of the workspace `proofs/Ieee754/` tree and into the literate option-3 form alongside the optimised circuit. The proof body comes verbatim from the closed `SubF32.lean` in the workspace; this is mechanical relocation, not new theorem work.

- New: `ieee754/proofs/sub_f32_preamble.lean` (imports + namespace + opens).
- New: `ieee754/proofs/sub_f32_equivalence.lean` (helpers + theorems + `end`).
- Edited: `ieee754/src/float32/mod.nr` — ASCII-only `LAMPE-LITERATE` directive lines beside `sub_float32_with_rounding`.
- Edited: `.gitignore` — adds `**/.lampe-literate/` for the per-source scratch tree.

The proof file inlines round-6 `add_f32_equivalence` so this PR is self-contained (independent of round-6 PR #60). IEEE 754-2019 §6.3 reduces sub to `add(a, negate(b))`, so the inlined `add_f32_equivalence` discharges the obligation directly. The splice tree for `mod.nr` is disjoint from `add.nr`'s, so the duplication never collides at build time.

See `proofs/Ieee754/PROOF-GAP-MATRIX.md` (Tier 1 / round 7a) for the round inventory and methodology.

## Test plan

- [x] `nargo check` passes (warnings unchanged from main).
- [x] `lampe-literate build ieee754/src/float32/mod.nr --config <workspace>/lampe-literate.toml` greens (lake build completes; `ZkpSparql.Generated` and `ZkpSparql` build without errors).
- [ ] Workspace `proofs/Ieee754/.../SubF32.lean` deletion lands as a separate workspace commit once this PR merges.