### PR TITLE
feat(proofs): migrate round-7b add_f64_equivalence to lampe-literate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ noir/lib/*/lampe/
 # module and the cached lake build. Regenerated from the literate Noir
 # directive lines each time `lampe-literate build` runs; never edited
 # by hand.
+# lampe-literate scratch dir (per-source). Contains the Lampe-extracted
+# Lean, the spliced proof module, and the cached lake build. Regenerated
+# from the literate Noir comment blocks each time `lampe-literate build`
+# runs; never edited by hand.
 **/.lampe-literate/
 
 # Node.js / semantic-release

--- a/ieee754/proofs/add_f64_equivalence.lean
+++ b/ieee754/proofs/add_f64_equivalence.lean
@@ -1,0 +1,40 @@
+/-! ## Diverging-parameter equalities -/
+
+/-- The optimised `clz` parameter equals the reference's (i.e. the
+binary-search and linear-loop CLZ are pointwise equal). -/
+private theorem clz_param_eq :
+    Subterms.clzBinary = Subterms.clzLoop := by
+  funext v; exact (Subterms.clz_eq v).symm
+
+/-- The optimised `rneDecision` parameter (inline-RNE wrapper) equals
+the reference's (`shouldRoundUp8Bit`). For `mode = 0` both sides
+reduce to the same boolean expression by
+`shouldRoundUp8Bit_inline_eq`; for `mode ≠ 0` the wrapper falls
+through to `shouldRoundUp8Bit` directly. -/
+private theorem rne_param_eq :
+    (fun (gb : BitVec 64) (rm : BitVec 64) (rs : BitVec 1) (m : BitVec 8) =>
+      if m = 0 then
+        decide (gb.toNat > 0x80) ||
+          (decide (gb = 0x80) && decide (rm &&& 1 = 1))
+      else
+        shouldRoundUp8Bit gb rm rs m) = shouldRoundUp8Bit := by
+  funext gb rm rs m
+  by_cases hmode : m = 0
+  · subst hmode
+    rw [if_pos rfl]
+    exact (shouldRoundUp8Bit_inline_eq gb rm rs).symm
+  · rw [if_neg hmode]
+
+/-! ## Main theorem -/
+
+/-- The optimised f64 add is bit-identical to the round-7 IEEE 754
+reference f64 add, for every input and every rounding mode. The
+proof rewrites both diverging-subterm parameters of the shared
+skeleton and lets `rfl` finish. -/
+theorem add_f64_equivalence
+    (a b : Float64Bits) (mode : BitVec 8) :
+    addF64Optimised a b mode = addF64Reference a b mode := by
+  unfold addF64Optimised addF64Reference
+  rw [clz_param_eq, rne_param_eq]
+
+end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/add_f64_equivalence.lean
+++ b/ieee754/proofs/add_f64_equivalence.lean
@@ -1,3 +1,9 @@
+-- This file is not standalone-compilable: it is spliced after
+-- `add_f64_preamble.lean` by lampe-literate (see the
+-- `LAMPE-LITERATE` directives in `ieee754/src/float64/add.nr`). The
+-- preamble opens the `ZkpSparql.Ieee754.Equivalence` namespace; the
+-- closing `end` below pairs with that opening across the splice.
+
 /-! ## Diverging-parameter equalities -/
 
 /-- The optimised `clz` parameter equals the reference's (i.e. the

--- a/ieee754/proofs/add_f64_preamble.lean
+++ b/ieee754/proofs/add_f64_preamble.lean
@@ -1,0 +1,7 @@
+import ZkpSparql.Ieee754.Equivalence.ModelsF64
+import ZkpSparql.Ieee754.Equivalence.SubtermsF64
+
+namespace ZkpSparql.Ieee754.Equivalence
+
+open ZkpSparql.Ieee754.Equivalence.ModelsF64
+open ZkpSparql.Ieee754.Equivalence.SubtermsF64

--- a/ieee754/src/float64/add.nr
+++ b/ieee754/src/float64/add.nr
@@ -20,6 +20,21 @@ use crate::utils::{
 // `crate::types` (i.e. `0..=4`). Any other value triggers an assertion
 // failure -- silently treating an unknown mode as round-to-nearest-even is
 // a footgun that masks calling-side bugs.
+//
+// ----------------------------------------------------------------------------
+// Lean equivalence proof (round 7b). See `circuits/lampe-literate` for the
+// build tool that resolves the LAMPE-LITERATE directives below, splices the
+// referenced proof file into a generated Lean module, and runs `lake build`
+// against the workspace's shared `ModelsF64.lean` / `SubtermsF64.lean`.
+// Generated `.lean` files land in a gitignored scratch dir; only this Noir
+// source plus the standalone `.lean` proof files are version-controlled.
+// Method: skeleton-and-specialisations -- the f64 path uses *explicit*
+// sticky flags, so there is no `shr_sticky` divergence to reconcile and
+// only two diverging-subterm parameters (`clz`, `rneDecision`) appear.
+// ----------------------------------------------------------------------------
+//
+// LAMPE-LITERATE preamble: ../../proofs/add_f64_preamble.lean
+// LAMPE-LITERATE proof:    ../../proofs/add_f64_equivalence.lean fn=add_float64_with_rounding name=add_f64_equivalence
 pub fn add_float64_with_rounding(
     a: IEEE754Float64,
     b: IEEE754Float64,


### PR DESCRIPTION
## Summary

Migrates the round-7 f64-add equivalence proof out of the workspace `proofs/Ieee754/` tree and into the literate option-3 form alongside the optimised circuit. The proof body comes verbatim from the closed `AddF64.lean` in the workspace; this is mechanical relocation, not new theorem work.

- New: `ieee754/proofs/add_f64_preamble.lean` (imports + namespace + opens).
- New: `ieee754/proofs/add_f64_equivalence.lean` (two diverging-subterm equalities + theorem + `end`).
- Edited: `ieee754/src/float64/add.nr` — ASCII-only `LAMPE-LITERATE` directive lines beside `add_float64_with_rounding`.
- Edited: `.gitignore` — adds `**/.lampe-literate/` for the per-source scratch tree.

The f64 path uses *explicit* sticky flags (rather than f32's inline-LSB-OR scheme), so there is no `shr_sticky` divergence to reconcile and only two diverging-subterm parameters (`clz`, `rneDecision`) appear in the skeleton.

See `proofs/Ieee754/PROOF-GAP-MATRIX.md` (Tier 1 / round 7b) for the round inventory and methodology.

## Test plan

- [x] `nargo check` passes (warnings unchanged from main).
- [x] `lampe-literate build ieee754/src/float64/add.nr --config <workspace>/lampe-literate.toml` greens (lake build completes; `ZkpSparql.Generated` and `ZkpSparql` build without errors).
- [ ] Workspace `proofs/Ieee754/.../AddF64.lean` deletion lands as a separate workspace commit once this PR merges.