### PR TITLE
proofs(utils): tier-6 lifts for shift_right_sticky_u64 / _u128

### DIFF
--- a/ieee754/proofs/shift_right_sticky_equivalence.lean
+++ b/ieee754/proofs/shift_right_sticky_equivalence.lean
@@ -1,0 +1,31 @@
+/-! # Equivalence theorems: sticky-shift family
+
+For each helper the optimised hand-port equals the literal
+IEEE 754-2019 sec 5.4.1 specification.
+
+* The u64 case is *definitionally* the same operation: the literal
+  spec (`Spec.shrSticky`) and the optimised dispatch share the same
+  3-branch shape, so `rfl` discharges the goal.
+* The u128 case threads the existing round-9 task-iii closure
+  (`SubtermsMulF64.shiftRightStickyU128_eq_spec`), which proves the
+  optimised 4-case dispatch matches the unified `Nat`-level spec. -/
+
+open ZkpSparql.Ieee754.Equivalence.Spec
+open ZkpSparql.Ieee754.Equivalence.MulModelsF64
+open ZkpSparql.Ieee754.Equivalence.SubtermsMulF64
+
+theorem shift_right_sticky_u64_equivalence
+    (value : BitVec 64) (shift : BitVec 64) :
+    shiftRightStickyU64Optimised value shift
+      = shiftRightStickyU64Spec value shift := by
+  unfold shiftRightStickyU64Optimised shiftRightStickyU64Spec shrSticky
+  rfl
+
+theorem shift_right_sticky_u128_equivalence
+    (val : U128) (shift : Nat) :
+    shiftRightStickyU128Optimised val shift
+      = shiftRightStickyU128SpecRef val shift := by
+  unfold shiftRightStickyU128Optimised shiftRightStickyU128SpecRef
+  exact shiftRightStickyU128_eq_spec val shift
+
+end ZkpSparql.Ieee754.Equivalence

--- a/ieee754/proofs/shift_right_sticky_preamble.lean
+++ b/ieee754/proofs/shift_right_sticky_preamble.lean
@@ -1,0 +1,85 @@
+import ZkpSparql.Ieee754.Equivalence.Spec
+import ZkpSparql.Ieee754.Equivalence.Subterms
+import ZkpSparql.Ieee754.Equivalence.MulModelsF64
+import ZkpSparql.Ieee754.Equivalence.SubtermsMulF64
+
+namespace ZkpSparql.Ieee754.Equivalence
+
+open ZkpSparql.Ieee754.Equivalence.Spec
+open ZkpSparql.Ieee754.Equivalence.MulModelsF64
+
+/-! # Tier-6 utility-lemma lifts: sticky-shift family
+
+The Noir helpers `shift_right_sticky_u64` and
+`shift_right_sticky_u128` (in `ieee754/src/utils.nr`) are the
+alignment primitives shared by the f32/f64 add, sub and mul
+circuits. Their correctness was already established inside the
+round-6/9 proofs (`Subterms.shr_sticky_eq` for the u64 case and
+`SubtermsMulF64.shiftRightStickyU128_eq_spec` for the u128 case);
+this file lifts the existing helper lemmas to top-level
+equivalence theorems associated with the public Noir function
+names per the `PROOF-GAP-MATRIX.md` Tier-6 row.
+
+* `shift_right_sticky_u64`'s optimised body is a 3-branch dispatch
+  on the shift amount. The literal IEEE 754-2019 sec 5.4.1
+  alignment specification (`Spec.shrSticky`) has the *same*
+  3-branch dispatch — the operation is its own minimal description
+  — so the equivalence is `rfl`.
+* `shift_right_sticky_u128`'s optimised body is a 4-case dispatch
+  bridging the two 64-bit halves of a `U128` payload. The literal
+  spec (`MulModelsF64.shiftRightStickyU128Spec`) re-expresses the
+  dispatch as a single arithmetic shift over the unified
+  `val.high * 2^64 + val.low` value with a sticky-OR for any
+  nonzero shifted-out bit. The closure is the round-9 `task iii`
+  result (`SubtermsMulF64.shiftRightStickyU128_eq_spec`).
+-/
+
+/-! ## `shift_right_sticky_u64` — literal hand-ports -/
+
+/-- Literal hand-port of `shift_right_sticky_u64` from
+`ieee754/src/utils.nr`: 3-branch dispatch on `shift`.
+The Noir body takes `(value : u64, shift : u64) -> u64`; we mirror
+that by accepting both arguments as `BitVec 64` and reading the
+shift amount via `shift.toNat` so the conditionals match the Noir
+control flow (`shift == 0`, `shift >= 64`, otherwise). -/
+def shiftRightStickyU64Optimised
+    (value : BitVec 64) (shift : BitVec 64) : BitVec 64 :=
+  let s := shift.toNat
+  if s = 0 then
+    value
+  else if s ≥ 64 then
+    if value = 0 then 0 else 1
+  else
+    let mask : BitVec 64 := (1 <<< s) - 1
+    let shiftedOut := value &&& mask
+    let result := value >>> s
+    if shiftedOut = 0 then result else result ||| 1
+
+/-- IEEE 754-2019 sec 5.4.1 alignment specification: shift right
+with sticky-bit preservation. Identical to `Spec.shrSticky` —
+re-exposed under the public Noir function name. -/
+def shiftRightStickyU64Spec
+    (value : BitVec 64) (shift : BitVec 64) : BitVec 64 :=
+  shrSticky value shift
+
+/-! ## `shift_right_sticky_u128` — literal hand-ports
+
+The Noir signature is `(val : U128, shift : u64) -> u64`. The Lean
+model in `MulModelsF64` already supplies the optimised dispatch
+(`shiftRightStickyU128`) and the unified `Nat`-level reference
+(`shiftRightStickyU128Spec`) under the convention that `shift` is
+read as `Nat` (the only reachable shift amounts are `0..=128`, so
+the `Nat` form mirrors the Noir source bit-for-bit). We re-export
+those as `Optimised` / `Spec` here. -/
+
+/-- Literal hand-port of `shift_right_sticky_u128` — re-export of
+`MulModelsF64.shiftRightStickyU128`. -/
+def shiftRightStickyU128Optimised
+    (val : U128) (shift : Nat) : BitVec 64 :=
+  MulModelsF64.shiftRightStickyU128 val shift
+
+/-- Literal IEEE 754-2019 sec 5.4.1 spec — re-export of
+`MulModelsF64.shiftRightStickyU128Spec`. -/
+def shiftRightStickyU128SpecRef
+    (val : U128) (shift : Nat) : BitVec 64 :=
+  MulModelsF64.shiftRightStickyU128Spec val shift

--- a/ieee754/src/utils.nr
+++ b/ieee754/src/utils.nr
@@ -9,6 +9,9 @@ use crate::types::{
 use std::ops::WrappingAdd;
 
 // Helper to shift right with sticky bit preservation for u64
+//
+// LAMPE-LITERATE preamble: ../proofs/shift_right_sticky_preamble.lean
+// LAMPE-LITERATE proof:    ../proofs/shift_right_sticky_equivalence.lean fn=shift_right_sticky_u64 name=shift_right_sticky_u64_equivalence
 pub fn shift_right_sticky_u64(value: u64, shift: u64) -> u64 {
     if shift == 0 {
         value
@@ -85,6 +88,8 @@ pub fn mul_u64_to_u128(a: u64, b: u64) -> U128 {
 }
 
 // Shift right a 128-bit value with sticky bit preservation
+//
+// LAMPE-LITERATE proof: ../proofs/shift_right_sticky_equivalence.lean fn=shift_right_sticky_u128 name=shift_right_sticky_u128_equivalence
 pub fn shift_right_sticky_u128(val: U128, shift: u64) -> u64 {
     if shift == 0 {
         val.low


### PR DESCRIPTION
## Summary

Lifts the two sticky-shift helpers in \`ieee754/src/utils.nr\` to
top-level Lean equivalence theorems associated with the public Noir
function names. Closes 2 cells of the
[\`PROOF-GAP-MATRIX.md\` Tier-6 row](../../proofs/Ieee754/PROOF-GAP-MATRIX.md#tier-6--utility-helpers-already-partially-proven-inside-other-rounds).

* \`shift_right_sticky_u64_equivalence\` reduces by \`rfl\` against
  \`Spec.shrSticky\` (the IEEE 754-2019 sec 5.4.1 alignment spec) —
  the optimised 3-branch dispatch is definitionally the same
  operation.
* \`shift_right_sticky_u128_equivalence\` threads the existing
  round-9 task-iii closure
  \`SubtermsMulF64.shiftRightStickyU128_eq_spec\`.

Two \`proof:\` directives in \`utils.nr\` share one
\`shift_right_sticky_equivalence.lean\` file, exercising the
\`lampe-literate#4\` dedup-by-(kind, path) fix.

## Test plan

- [x] \`nargo check\` clean (no new warnings).
- [x] \`lampe-literate build circuits/noir_IEEE754/ieee754/src/utils.nr\` runs \`lake build\` to green.
- [ ] CI \`copilot-review-posted\` SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)