### PR TITLE
ci: auto-update PR branches that have auto-merge armed and are BEHIND

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -59,7 +59,7 @@ jobs:
           for n in $numbers; do
             echo "::group::PR #$n"
             if ! gh pr update-branch "$n" --repo "$REPO"; then
-              echo "warn: update-branch failed on #$n (will retry next cycle)"
+              echo "::warning::update-branch failed on #$n (will retry next cycle)"
             fi
             echo "::endgroup::"
             sleep 2

--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -1,0 +1,66 @@
+name: Auto-update auto-merge PR branches
+
+# When `main` moves or every 15 minutes, find every open PR that has
+# auto-merge armed and is in `BEHIND` state, then `gh pr update-branch`
+# it so its CI re-runs and the auto-merge gate can clear.
+#
+# Closes the gap where GitHub's `allow_update_branch=true` setting only
+# *suggests* the "Update branch" UI button rather than performing the
+# rebase automatically: with auto-merge armed, the merge gate keeps
+# blocking on the head being out-of-date, but nothing nudges the rebase
+# unless someone polls externally. The previous workflow for this lived
+# as ad-hoc `gh pr update-branch` loops in lead-agent sessions; this
+# moves it inside CI so the cascade keeps draining without manual nudges.
+#
+# Only `BEHIND` PRs are touched. `BLOCKED`, `UNSTABLE`, etc. are left
+# alone — those are waiting on review or check completion, not on a
+# rebase.
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: auto-update-pr-branches
+  cancel-in-progress: false
+
+jobs:
+  update-branches:
+    name: Refresh BEHIND PRs that have auto-merge enabled
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update branches via gh CLI
+        env:
+          # Must be a PAT (not the default GITHUB_TOKEN) so the rebase
+          # commits trigger downstream CI workflows. Same rationale as
+          # `automerge.yml` in this repo.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          numbers=$(
+            gh pr list --repo "$REPO" --state open \
+              --json number,autoMergeRequest,mergeStateStatus \
+              --jq '.[] | select(.autoMergeRequest != null and .mergeStateStatus == "BEHIND") | .number'
+          )
+          if [ -z "$numbers" ]; then
+            echo "No BEHIND auto-merge PRs to update."
+            exit 0
+          fi
+          echo "BEHIND auto-merge PRs to refresh:"
+          echo "$numbers"
+          for n in $numbers; do
+            echo "::group::PR #$n"
+            if ! gh pr update-branch "$n" --repo "$REPO"; then
+              echo "warn: update-branch failed on #$n (will retry next cycle)"
+            fi
+            echo "::endgroup::"
+            sleep 2
+          done

--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -5,16 +5,17 @@ name: Auto-update auto-merge PR branches
 # it so its CI re-runs and the auto-merge gate can clear.
 #
 # Closes the gap where GitHub's `allow_update_branch=true` setting only
-# *suggests* the "Update branch" UI button rather than performing the
-# rebase automatically: with auto-merge armed, the merge gate keeps
-# blocking on the head being out-of-date, but nothing nudges the rebase
-# unless someone polls externally. The previous workflow for this lived
-# as ad-hoc `gh pr update-branch` loops in lead-agent sessions; this
-# moves it inside CI so the cascade keeps draining without manual nudges.
+# *suggests* the "Update branch" UI button rather than merging the base
+# into the branch automatically: with auto-merge armed, the merge gate
+# keeps blocking on the head being out-of-date, but nothing triggers the
+# branch update unless someone polls externally. The previous workflow
+# for this lived as ad-hoc `gh pr update-branch` loops in lead-agent
+# sessions; this moves it inside CI so the cascade keeps draining
+# without manual nudges.
 #
 # Only `BEHIND` PRs are touched. `BLOCKED`, `UNSTABLE`, etc. are left
 # alone — those are waiting on review or check completion, not on a
-# rebase.
+# branch update (merge base into branch).
 
 on:
   push:
@@ -38,7 +39,7 @@ jobs:
     steps:
       - name: Update branches via gh CLI
         env:
-          # Must be a PAT (not the default GITHUB_TOKEN) so the rebase
+          # Must be a PAT (not the default GITHUB_TOKEN) so the update-branch
           # commits trigger downstream CI workflows. Same rationale as
           # `automerge.yml` in this repo.
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           set -euo pipefail
           numbers=$(
-            gh pr list --repo "$REPO" --state open \
+            gh pr list --repo "$REPO" --state open --limit 1000 \
               --json number,autoMergeRequest,mergeStateStatus \
               --jq '.[] | select(.autoMergeRequest != null and .mergeStateStatus == "BEHIND") | .number'
           )


### PR DESCRIPTION
## Summary

Closes the cascade-stall pattern surfaced during Wave 15 of the
ZKP-SPARQL workspace (see workspace PR#86 / `HANDOFF-NEXT-AGENT.md`).

GitHub's `allow_update_branch=true` setting only *suggests* the
"Update branch" UI button rather than performing the rebase
automatically. With auto-merge armed, the merge gate keeps blocking
on the head being out-of-date, so when one PR merges and main
moves, the rest of the cascade stalls until someone polls
`gh pr update-branch` externally.

This workflow runs on `push` to main and every 15 minutes as a
backstop, finds every open PR that has auto-merge enabled and is
in `BEHIND` state, and rebases each one. CI re-runs on the
rebased heads, and auto-merge fires as each goes green.

## Why a PAT and not `GITHUB_TOKEN`

Uses `secrets.GH_TOKEN` (a PAT) so the rebase commits trigger
downstream CI workflows. The default `GITHUB_TOKEN` does not
trigger workflows on commits it pushes — same constraint that
`automerge.yml` already documents in this repo.

## Scope

- Only PRs with `autoMergeRequest != null` and `mergeStateStatus == "BEHIND"` are touched.
- `BLOCKED`, `UNSTABLE`, `CLEAN`, `DRAFT`, `UNKNOWN` etc. are left alone — those are waiting on review or check completion, not on a rebase.
- `concurrency: auto-update-pr-branches` (`cancel-in-progress: false`) prevents overlapping runs from racing on the same PR set.

## Test plan

- [ ] Workflow appears under Actions tab once merged.
- [ ] First scheduled run (within 15 min of merge) on a quiet repo: should report "No BEHIND auto-merge PRs to update."
- [ ] Push to main with one or more BEHIND auto-merge PRs: workflow updates each branch, CI re-fires, auto-merge clears as each goes green.
- [ ] If `GH_TOKEN` is missing: failure is loud (workflow run fails on the first `gh` call). The repo already uses `GH_TOKEN` for `automerge.yml` so the secret should already be set.

## Replication

If this works here, the canonical copy belongs in
`templates/sub-repo/noir/.github/workflows/` in the workspace and
should be propagated via `scripts/sync-standards.sh` to
`circuits/sparql_noir`, `circuits/noir_XPath`, etc. — happy to
follow up with that workspace-side PR once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)