### PR TITLE
ci: tighten Copilot review gate + label-driven Claude routine + merge-queue support

### DIFF
--- a/.github/workflows/claude-on-label.yml
+++ b/.github/workflows/claude-on-label.yml
@@ -1,0 +1,66 @@
+name: Dispatch Claude routine on address-review-comments label
+
+# When a PR is labelled `address-review-comments` (typically by the
+# `require-copilot-review.yml` gate when it detects unresolved Copilot
+# threads, but a maintainer can also apply it manually), fire the
+# pre-configured remote Claude Code routine that addresses the threads.
+#
+# The routine itself runs in Anthropic's cloud — this workflow does not
+# run Claude inside the PR's Actions context. It only makes a single
+# `POST .../triggers/{id}/run` API call to dispatch the routine. The
+# routine then walks the PR, addresses each thread, removes the label
+# when done, and reports back via PR comments.
+#
+# Required repo secret:
+#   CLAUDE_CODE_TOKEN — a claude.ai/code OAuth token authorised to
+#   trigger the routine. Set via:
+#     gh secret set CLAUDE_CODE_TOKEN --repo jeswr/noir_IEEE754
+#   (paste a short-lived token from claude.ai/code, or a long-lived
+#   token if your account supports them).
+#
+# The trigger ID below is the workspace-managed routine
+# `trig_01Ww6Q1N6VKRUta4a649Ujm7` ("Address noir_IEEE754 PRs labelled
+# address-review-comments"). If the routine is recreated, update
+# `TRIGGER_ID` in the env block below.
+#
+# This file is managed by `scripts/sync-standards.sh` (workspace).
+# Edit the canonical at:
+#   templates/sub-repo/noir/.github/workflows/claude-on-label.yml
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    if: github.event.label.name == 'address-review-comments'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fire claude.ai/code routine
+        env:
+          CLAUDE_CODE_TOKEN: ${{ secrets.CLAUDE_CODE_TOKEN }}
+          TRIGGER_ID: trig_01Ww6Q1N6VKRUta4a649Ujm7
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${CLAUDE_CODE_TOKEN:-}" ]]; then
+            echo "::error::CLAUDE_CODE_TOKEN secret is not set."
+            echo "Set via:  gh secret set CLAUDE_CODE_TOKEN --repo ${{ github.repository }}"
+            exit 1
+          fi
+          # POST to the run-now endpoint. The routine is configured to
+          # discover the labelled PR by querying the repo's open PRs
+          # for the `address-review-comments` label, so the body is
+          # empty — no per-PR parameters.
+          response=$(curl -fsSL -X POST \
+            -H "Authorization: Bearer ${CLAUDE_CODE_TOKEN}" \
+            -H "Content-Type: application/json" \
+            "https://claude.ai/api/v1/code/triggers/${TRIGGER_ID}/run" \
+            -d '{}')
+          echo "::notice::Dispatched Claude routine ${TRIGGER_ID} for PR #${PR_NUMBER} (${PR_URL})."
+          echo "$response" | jq -c . || echo "$response"

--- a/.github/workflows/require-copilot-review.yml
+++ b/.github/workflows/require-copilot-review.yml
@@ -45,11 +45,15 @@ on:
       - converted_to_draft
   pull_request_review:
     types: [submitted, edited, dismissed]
-  # Re-run when reviewers (or PR authors) resolve / unresolve threads,
-  # so the gate flips green the moment the last Copilot thread is
-  # resolved — and red again if any thread is unresolved.
-  pull_request_review_thread:
-    types: [resolved, unresolved]
+  # Note: there is *no* `pull_request_review_thread` Actions trigger
+  # (it exists as a webhook event but does not fire workflows). When a
+  # reviewer / author resolves a thread, this gate does NOT auto-rerun —
+  # the gate re-evaluates on the next `pull_request.synchronize` (push to
+  # the PR head). The remote routine that resolves threads pushes its
+  # commits to the PR head, which fires `synchronize` and refreshes the
+  # gate; manual thread resolution requires a separate push or a
+  # workflow_dispatch run.
+  workflow_dispatch:
 
 permissions:
   # `write` so this workflow can apply / remove the
@@ -214,9 +218,12 @@ jobs:
           echo "::error::PR #$PR_NUMBER has $unresolved unresolved Copilot review thread(s)."
           echo "Each thread must be resolved before merge — either by addressing the"
           echo "comment with a code change, or by replying with the rationale and"
-          echo "clicking 'Resolve conversation'. The check re-runs on every"
-          echo "pull_request_review_thread event so it will turn green the moment"
-          echo "the last thread is resolved."
+          echo "clicking 'Resolve conversation'."
+          echo
+          echo "Note: GitHub does not fire workflow events on thread resolution"
+          echo "alone, so this gate will NOT auto-re-run when you click 'Resolve"
+          echo "conversation'. It re-evaluates on the next push to the PR head"
+          echo "(synchronize), or run the workflow manually via the Actions tab."
           # Apply the `address-review-comments` label so the
           # `claude-on-label.yml` workflow can dispatch the remote
           # Claude routine to address the threads autonomously. The

--- a/.github/workflows/require-copilot-review.yml
+++ b/.github/workflows/require-copilot-review.yml
@@ -1,16 +1,26 @@
 name: Require Copilot review
 
-# Gate: merge to `main` is blocked until `copilot-pull-request-reviewer[bot]`
-# has posted at least one review on the PR. This workflow exposes a required
-# status check (`copilot-review-posted`) consumed by the repo ruleset on
-# `~DEFAULT_BRANCH`.
+# Gate: merge to `main` is blocked until BOTH conditions hold:
+#   1. `copilot-pull-request-reviewer[bot]` has posted at least one
+#      non-DISMISSED review on the PR.
+#   2. Every review thread authored by Copilot is resolved (either by
+#      addressing the comment in code, or by replying with rationale
+#      and clicking "Resolve conversation").
 #
-# Rationale: per `notes/research/pr-review-audit-2026-05-03.md`, 15 of 56
-# merged-with-review PRs across the three sub-repos were merged BEFORE
-# Copilot's first review timestamp. This workflow closes that gap. It does
-# *not* enforce thread resolution — only that a review has been posted.
+# This workflow exposes a required status check (`copilot-review-posted`)
+# consumed by the repo ruleset on `~DEFAULT_BRANCH`.
 #
-# Exemptions (the check passes without a review):
+# Rationale (review-posted half): per
+# `notes/research/pr-review-audit-2026-05-03.md`, 15 of 56 merged-with-
+# review PRs across the three sub-repos were merged BEFORE Copilot's
+# first review timestamp.
+#
+# Rationale (threads-resolved half): per Wave 15 audit (workspace 2026-
+# 05-08), Copilot review *findings* were routinely left unaddressed —
+# review-posted alone passed the gate without anyone having engaged
+# with the comments. Requiring thread resolution closes that gap.
+#
+# Exemptions (the check passes without any review or resolution):
 #   - Author is `dependabot[bot]` — Copilot does not review dep bumps.
 #   - Author is `Copilot` (the coding agent) — Copilot does not review its
 #     own PRs.
@@ -35,6 +45,11 @@ on:
       - converted_to_draft
   pull_request_review:
     types: [submitted, edited, dismissed]
+  # Re-run when reviewers (or PR authors) resolve / unresolve threads,
+  # so the gate flips green the moment the last Copilot thread is
+  # resolved — and red again if any thread is unresolved.
+  pull_request_review_thread:
+    types: [resolved, unresolved]
 
 permissions:
   pull-requests: read
@@ -43,9 +58,9 @@ permissions:
 jobs:
   copilot-review-posted:
     name: copilot-review-posted
-    # Skip pull_request_review events targeting non-default branches; the
-    # `pull_request_review` trigger does not honour the `branches:` filter
-    # above, so we gate it explicitly here.
+    # Skip review/thread events targeting non-default branches; those
+    # triggers do not honour the `branches:` filter above, so we gate
+    # them explicitly here.
     if: >-
       github.event_name == 'pull_request' ||
       github.event.pull_request.base.ref == 'main'
@@ -107,10 +122,72 @@ jobs:
             | awk '{s+=$1} END {print s+0}')
           if [[ "$reviewers" -ge 1 ]]; then
             echo "::notice::Copilot has posted $reviewers review(s) on PR #$PR_NUMBER."
+          else
+            echo "::error::No review from copilot-pull-request-reviewer[bot] yet on PR #$PR_NUMBER."
+            echo "If Copilot review has not been requested, request one. The check"
+            echo "re-runs on each pull_request_review event, so it will turn green"
+            echo "once Copilot posts."
+            exit 1
+          fi
+
+      - name: Check that all Copilot review threads are resolved
+        if: steps.exempt.outputs.exempt != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          # Query review threads via GraphQL — REST has no per-thread
+          # `isResolved` field. Connection page size is capped at 100;
+          # PRs with >100 threads are extremely rare and would warrant
+          # manual triage. If we ever hit that ceiling we can paginate
+          # via `pageInfo.endCursor`.
+          QUERY='query($owner: String!, $name: String!, $number: Int!) {
+            repository(owner: $owner, name: $name) {
+              pullRequest(number: $number) {
+                reviewThreads(first: 100) {
+                  nodes {
+                    isResolved
+                    isOutdated
+                    comments(first: 1) {
+                      nodes { author { login } }
+                    }
+                  }
+                }
+              }
+            }
+          }'
+          response=$(gh api graphql \
+            -f query="$QUERY" \
+            -F owner="$REPO_OWNER" \
+            -F name="$REPO_NAME" \
+            -F number="$PR_NUMBER")
+          # Filter to threads whose first comment is by Copilot. Both
+          # `Copilot` (line-comment surface) and
+          # `copilot-pull-request-reviewer` (review-summary surface) are
+          # accepted to be defensive across the bot's two identities.
+          # Outdated threads — those targeting a line the author later
+          # replaced — are exempted, since GitHub does not let anyone
+          # resolve them via UI in the usual way.
+          unresolved=$(echo "$response" | jq '[
+            .data.repository.pullRequest.reviewThreads.nodes[]
+            | select(
+                (.comments.nodes[0].author.login == "Copilot")
+                or (.comments.nodes[0].author.login == "copilot-pull-request-reviewer")
+              )
+            | select(.isResolved == false)
+            | select(.isOutdated == false)
+          ] | length')
+          if [[ "$unresolved" -eq 0 ]]; then
+            echo "::notice::All Copilot review threads on PR #$PR_NUMBER are resolved."
             exit 0
           fi
-          echo "::error::No review from copilot-pull-request-reviewer[bot] yet on PR #$PR_NUMBER."
-          echo "If Copilot review has not been requested, request one. The check"
-          echo "re-runs on each pull_request_review event, so it will turn green"
-          echo "once Copilot posts."
+          echo "::error::PR #$PR_NUMBER has $unresolved unresolved Copilot review thread(s)."
+          echo "Each thread must be resolved before merge — either by addressing the"
+          echo "comment with a code change, or by replying with the rationale and"
+          echo "clicking 'Resolve conversation'. The check re-runs on every"
+          echo "pull_request_review_thread event so it will turn green the moment"
+          echo "the last thread is resolved."
           exit 1

--- a/.github/workflows/require-copilot-review.yml
+++ b/.github/workflows/require-copilot-review.yml
@@ -52,7 +52,10 @@ on:
     types: [resolved, unresolved]
 
 permissions:
-  pull-requests: read
+  # `write` so this workflow can apply / remove the
+  # `address-review-comments` label that drives the remote Claude
+  # routine (see `claude-on-label.yml`).
+  pull-requests: write
   contents: read
 
 jobs:
@@ -199,6 +202,13 @@ jobs:
           ] | length')
           if [[ "$unresolved" -eq 0 ]]; then
             echo "::notice::All Copilot review threads on PR #$PR_NUMBER are resolved."
+            # Cleanup: if a previous run applied the
+            # `address-review-comments` label and the routine has now
+            # cleared all the threads, remove the label so the PR no
+            # longer shows up in the labelled set.
+            gh pr edit "$PR_NUMBER" --repo "$REPO_OWNER/$REPO_NAME" \
+              --remove-label "address-review-comments" 2>/dev/null \
+              || true
             exit 0
           fi
           echo "::error::PR #$PR_NUMBER has $unresolved unresolved Copilot review thread(s)."
@@ -207,4 +217,13 @@ jobs:
           echo "clicking 'Resolve conversation'. The check re-runs on every"
           echo "pull_request_review_thread event so it will turn green the moment"
           echo "the last thread is resolved."
+          # Apply the `address-review-comments` label so the
+          # `claude-on-label.yml` workflow can dispatch the remote
+          # Claude routine to address the threads autonomously. The
+          # label is idempotent — re-applying when already present is
+          # a no-op. The companion workflow removes it once the
+          # routine has cleared the threads.
+          gh pr edit "$PR_NUMBER" --repo "$REPO_OWNER/$REPO_NAME" \
+            --add-label "address-review-comments" 2>/dev/null \
+            || echo "::warning::Could not apply address-review-comments label (label may not exist in this repo yet)."
           exit 1

--- a/.github/workflows/require-copilot-review.yml
+++ b/.github/workflows/require-copilot-review.yml
@@ -140,14 +140,17 @@ jobs:
         run: |
           set -euo pipefail
           # Query review threads via GraphQL — REST has no per-thread
-          # `isResolved` field. Connection page size is capped at 100;
-          # PRs with >100 threads are extremely rare and would warrant
-          # manual triage. If we ever hit that ceiling we can paginate
-          # via `pageInfo.endCursor`.
+          # `isResolved` field. Connection page size is capped at 100,
+          # so we MUST fail closed if the PR has more than 100 review
+          # threads — letting the gate silently truncate would let an
+          # unresolved Copilot thread on the >100 tail slip through.
+          # PRs with >100 threads are exotic; if this ever fires in
+          # anger we paginate via `pageInfo.endCursor`.
           QUERY='query($owner: String!, $name: String!, $number: Int!) {
             repository(owner: $owner, name: $name) {
               pullRequest(number: $number) {
                 reviewThreads(first: 100) {
+                  pageInfo { hasNextPage endCursor }
                   nodes {
                     isResolved
                     isOutdated
@@ -164,10 +167,23 @@ jobs:
             -F owner="$REPO_OWNER" \
             -F name="$REPO_NAME" \
             -F number="$PR_NUMBER")
-          # Filter to threads whose first comment is by Copilot. Both
-          # `Copilot` (line-comment surface) and
-          # `copilot-pull-request-reviewer` (review-summary surface) are
-          # accepted to be defensive across the bot's two identities.
+          # Fail closed if the connection was truncated.
+          has_next=$(echo "$response" | jq -r \
+            '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+          if [[ "$has_next" == "true" ]]; then
+            echo "::error::PR #$PR_NUMBER has more than 100 review threads;"
+            echo "this gate does not paginate yet so it fails closed rather"
+            echo "than risk silently passing on an unresolved Copilot thread"
+            echo "on the tail. File an issue to add cursor pagination."
+            exit 1
+          fi
+          # Filter to threads whose first comment is by Copilot. The bot
+          # has multiple login surfaces in practice:
+          #   - GraphQL `author.login` for the review-summary identity
+          #     usually returns `copilot-pull-request-reviewer` (no
+          #     `[bot]` suffix); REST returns the same name with `[bot]`.
+          #   - GraphQL line-comment author returns `Copilot`.
+          # We accept all three to be defensive across surface drift.
           # Outdated threads — those targeting a line the author later
           # replaced — are exempted, since GitHub does not let anyone
           # resolve them via UI in the usual way.
@@ -176,6 +192,7 @@ jobs:
             | select(
                 (.comments.nodes[0].author.login == "Copilot")
                 or (.comments.nodes[0].author.login == "copilot-pull-request-reviewer")
+                or (.comments.nodes[0].author.login == "copilot-pull-request-reviewer[bot]")
               )
             | select(.isResolved == false)
             | select(.isOutdated == false)


### PR DESCRIPTION
## Summary

Closes the loop between the Copilot review gate, a remote Claude Code routine that addresses unresolved threads, and (now) the GitHub merge queue — without running Claude inside the PR's Actions context.

The label `address-review-comments` is the bridge between the gate and the routine. Merge queue support lets you batch-merge PRs efficiently when the cascade is busy.

## What changes

### `require-copilot-review.yml` (strengthened gate + label management + merge-queue support)

- Fails the gate when **any** Copilot review thread is unresolved (and not outdated). Uses GraphQL `reviewThreads` (REST has no per-thread `isResolved`).
- Filter accepts all three Copilot identities (`Copilot`, `copilot-pull-request-reviewer`, `copilot-pull-request-reviewer[bot]`).
- Fails closed if PR has > 100 threads (GraphQL connection ceiling) — addressed in inline review feedback.
- Applies `address-review-comments` label when threads are unresolved; removes it when all are resolved. Both ops idempotent.
- Permission bumped from `pull-requests: read` to `write` for label management.
- Adds `merge_group:` trigger and a merge-queue auto-pass step. The Copilot review is verified at PR-merge-add time; queue context has no `github.event.pull_request` payload, so re-verifying on the merge ref is unnecessary and impossible.
- Adds `workflow_dispatch:` so the routine can manually nudge the gate after pure reply-and-resolve operations.
- Drops the invalid `pull_request_review_thread` trigger (it's a webhook event, not an Actions trigger — was making the workflow fail to parse).

### `ci.yml` (merge-queue support)

- Adds `merge_group:` trigger so `test-summary` (required check) runs on the integrated merge ref. The `if: github.event.pull_request.draft != true` gate degrades cleanly: in `merge_group` context `github.event.pull_request` is undefined, so the comparison is `null != true` (= true) and all jobs run.

### `claude-on-label.yml` (new dispatcher)

- Triggers on `pull_request.labeled` filtered to `address-review-comments`.
- Single step: `POST` to the claude.ai/code routine run-now endpoint (`trig_01Ww6Q1N6VKRUta4a649Ujm7` — *"Address noir_IEEE754 PRs labelled address-review-comments"*).
- The routine runs in Anthropic's cloud — no Claude execution in the PR's Actions context.

## End-to-end flow (current)

1. Copilot reviews PR.
2. `require-copilot-review.yml` finds unresolved threads → fails the gate **and** applies `address-review-comments` label.
3. `claude-on-label.yml` fires on the label-add → `POST .../triggers/{id}/run`.
4. Routine wakes in Anthropic cloud, walks the PR, picks (a) code fix / (b) reply+resolve / (c) triage-only per thread; pushes commits where applicable; resolves threads via GraphQL.
5. Routine removes the label, then nudges the gate (`gh workflow run require-copilot-review.yml`) if no commits were pushed.
6. Gate re-evaluates → green if all threads resolved → PR mergeable.

## End-to-end flow (with merge queue, after ruleset flip)

1-6 as above, then:
7. Merge queue picks up PRs with auto-merge armed and adds them to the queue in batches.
8. Required checks (`test-summary`, `copilot-review-posted`) run on the integrated merge ref — `test-summary` runs full CI, `copilot-review-posted` auto-passes.
9. Queue merges in order; if any check fails, the failing PR is bounced and the rest re-evaluate.

## Required setup before this PR is fully effective

| | |
|---|---|
| **Repo secret `CLAUDE_CODE_TOKEN`** | claude.ai/code OAuth token. Set via `gh secret set CLAUDE_CODE_TOKEN --repo jeswr/noir_IEEE754`. Without it, `claude-on-label.yml` fails loudly. |
| **API host in `claude-on-label.yml`** | Currently `https://claude.ai/api/v1/code/triggers/{id}/run`. If your account routes through `api.anthropic.com`, swap the URL. |
| **Label `address-review-comments`** | Already created in this repo. |
| **Routine `trig_01Ww6Q1N6VKRUta4a649Ujm7`** | Already configured + enabled. |
| **Merge queue rule on the `~DEFAULT_BRANCH` ruleset** | NOT yet enabled. See API command below. |

## How to enable the merge queue (run manually after this PR lands)

The `~DEFAULT_BRANCH` ruleset (id `11111001`) currently has rules: `deletion`, `non_fast_forward`, `required_linear_history`, `pull_request`, `required_status_checks`. Add a `merge_queue` rule:

```sh
gh api -X PUT repos/jeswr/noir_IEEE754/rulesets/11111001 \
  --input - <<'JSON'
{
  "name": "main",
  "target": "branch",
  "enforcement": "active",
  "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
  "rules": [
    {"type": "deletion"},
    {"type": "non_fast_forward"},
    {"type": "required_linear_history"},
    {"type": "pull_request"},
    {"type": "required_status_checks", "parameters": {
      "strict_required_status_checks_policy": false,
      "required_status_checks": [
        {"context": "test-summary"},
        {"context": "copilot-review-posted"}
      ]
    }},
    {"type": "merge_queue", "parameters": {
      "check_response_timeout_minutes": 60,
      "grouping_strategy": "ALLGREEN",
      "max_entries_to_build": 5,
      "max_entries_to_merge": 5,
      "merge_method": "SQUASH",
      "min_entries_to_merge": 1,
      "min_entries_to_merge_wait_minutes": 5
    }}
  ]
}
JSON
```

I deliberately did NOT execute this myself — repo-level ruleset changes need explicit authorisation. Run it after this PR merges, then arm auto-merge on a test PR to confirm the queue picks it up.

## Tier-4 protection

The routine treats Copilot comments on Tier-4 closure PRs (#63 / #68 / #69 / #71 / #87) as triage-only, never makes code changes. Built into the routine prompt.

## Test plan

- [ ] After merge, set `CLAUDE_CODE_TOKEN` secret if not already present.
- [ ] After merge, run the ruleset API command above to enable the queue.
- [ ] On a PR where Copilot has left an unresolved comment: gate fails → label applied → routine fires → threads addressed → label removed → gate re-runs → passes.
- [ ] On a PR with merge queue armed: queue rebases, runs checks on integrated merge ref, merges in order.
- [ ] Tier-4 PR with Copilot comment: routine posts triage comment, removes label, threads remain unresolved (gate stays red) → manual handling.

## Replication

Once stable in `noir_IEEE754`, propagate via workspace `templates/sub-repo/noir/.github/workflows/` + `scripts/sync-standards.sh` to `sparql_noir`, `noir_XPath`, `sparql-zkp-ontologies`, `lampe-literate`, `sparql-noir-modular`. Each repo gets its own routine with its own slug and skip set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
