### PR TITLE
fix(ci): use PAT (GH_TOKEN) for label management so downstream workflows fire

### DIFF
--- a/.github/workflows/claude-on-label.yml
+++ b/.github/workflows/claude-on-label.yml
@@ -53,14 +53,37 @@ jobs:
             echo "Set via:  gh secret set CLAUDE_CODE_TOKEN --repo ${{ github.repository }}"
             exit 1
           fi
+          # Strip CR / LF and surrounding whitespace from the secret.
+          # `claude setup-token` outputs the token with a trailing
+          # newline; GitHub stores secrets verbatim (no trim), and curl
+          # rejects header values containing CR / LF with
+          # `CURLE_BAD_FUNCTION_ARGUMENT` (exit 43) before the network
+          # call. Bearer tokens never legitimately contain whitespace,
+          # so trimming is safe and idempotent for cleanly-pasted ones.
+          TOKEN=$(printf '%s' "$CLAUDE_CODE_TOKEN" | tr -d '[:space:]')
+          if [[ "${#TOKEN}" -lt 16 ]]; then
+            echo "::error::CLAUDE_CODE_TOKEN looks too short (${#TOKEN} chars after trim) — re-run \`claude setup-token\` and re-set the secret."
+            exit 1
+          fi
           # POST to the run-now endpoint. The routine is configured to
           # discover the labelled PR by querying the repo's open PRs
           # for the `address-review-comments` label, so the body is
           # empty — no per-PR parameters.
-          response=$(curl -fsSL -X POST \
-            -H "Authorization: Bearer ${CLAUDE_CODE_TOKEN}" \
+          # `-w '%{http_code}'` separates response body from status so
+          # we can fail loudly with a useful message on auth errors
+          # (401 / 403) without `curl -f` swallowing the body.
+          http_status=$(curl -sS -X POST \
+            -o /tmp/dispatch-response.json -w '%{http_code}' \
+            -H "Authorization: Bearer ${TOKEN}" \
             -H "Content-Type: application/json" \
             "https://claude.ai/api/v1/code/triggers/${TRIGGER_ID}/run" \
             -d '{}')
-          echo "::notice::Dispatched Claude routine ${TRIGGER_ID} for PR #${PR_NUMBER} (${PR_URL})."
-          echo "$response" | jq -c . || echo "$response"
+          echo "::notice::Dispatch HTTP ${http_status} for PR #${PR_NUMBER} (${PR_URL})."
+          if [[ "$http_status" -ge 200 && "$http_status" -lt 300 ]]; then
+            jq -c . /tmp/dispatch-response.json 2>/dev/null \
+              || cat /tmp/dispatch-response.json
+            exit 0
+          fi
+          echo "::error::Dispatch failed with HTTP ${http_status}. Response body:"
+          cat /tmp/dispatch-response.json
+          exit 1

--- a/.github/workflows/require-copilot-review.yml
+++ b/.github/workflows/require-copilot-review.yml
@@ -140,7 +140,19 @@ jobs:
       - name: Check that all Copilot review threads are resolved
         if: steps.exempt.outputs.exempt != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Must be a PAT (`secrets.GH_TOKEN`), NOT the default
+          # `GITHUB_TOKEN`, because this step applies / removes the
+          # `address-review-comments` label and we need the resulting
+          # `pull_request.labeled` event to trigger the downstream
+          # `claude-on-label.yml` workflow. GitHub Actions deliberately
+          # does NOT fire workflows on events caused by the default
+          # `GITHUB_TOKEN` (anti-recursion), so labelling under
+          # `GITHUB_TOKEN` was silently a no-op for the dispatcher.
+          # Same rationale as `automerge.yml` in this repo.
+          # The graphql query in this step is read-only and works
+          # equivalently under either token, so a single env var
+          # covers both the query and the mutating label calls.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/require-copilot-review.yml
+++ b/.github/workflows/require-copilot-review.yml
@@ -140,19 +140,16 @@ jobs:
       - name: Check that all Copilot review threads are resolved
         if: steps.exempt.outputs.exempt != 'true'
         env:
-          # Must be a PAT (`secrets.GH_TOKEN`), NOT the default
-          # `GITHUB_TOKEN`, because this step applies / removes the
-          # `address-review-comments` label and we need the resulting
-          # `pull_request.labeled` event to trigger the downstream
-          # `claude-on-label.yml` workflow. GitHub Actions deliberately
-          # does NOT fire workflows on events caused by the default
-          # `GITHUB_TOKEN` (anti-recursion), so labelling under
-          # `GITHUB_TOKEN` was silently a no-op for the dispatcher.
-          # Same rationale as `automerge.yml` in this repo.
-          # The graphql query in this step is read-only and works
-          # equivalently under either token, so a single env var
-          # covers both the query and the mutating label calls.
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          # Prefer the PAT (`secrets.GH_TOKEN`) so apply/remove-label
+          # operations can emit downstream workflow-triggering events on
+          # same-repo PRs. Fall back to the default token on fork PRs,
+          # where secrets are not passed, so the read-only GraphQL query
+          # still authenticates instead of failing with an empty token.
+          # GitHub Actions deliberately does NOT fire workflows on events
+          # caused by the default `GITHUB_TOKEN` (anti-recursion), so the
+          # fallback preserves required-check reliability but not the
+          # downstream label-trigger behavior for forks.
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}


### PR DESCRIPTION
## Summary

\`require-copilot-review.yml\` applied the \`address-review-comments\` label using the default \`GITHUB_TOKEN\`. GitHub Actions deliberately does NOT trigger downstream workflows on events caused by \`GITHUB_TOKEN\` (anti-recursion guard), so the resulting \`pull_request.labeled\` event was a silent no-op for \`claude-on-label.yml\`.

Three PRs accumulated the label without the remote routine ever firing: #60, #86, #87.

## Diagnosis (before the fix)

\`\`\`
$ gh run list --workflow claude-on-label.yml
[]                                              # zero runs ever

$ gh pr list --label address-review-comments
#60, #86, #87                                   # label applied but no dispatcher run
\`\`\`

## Fix

Switch the env on the \"Check that all Copilot review threads are resolved\" step from \`secrets.GITHUB_TOKEN\` to \`secrets.GH_TOKEN\` (the PAT this repo already uses for \`automerge.yml\` for the same reason). The graphql query in the same step is read-only and works equivalently under either token, so a single env var covers both the query and the mutating label calls.

## Required for the loop to actually close

| | |
|---|---|
| \`secrets.GH_TOKEN\` | already set (\`automerge.yml\` uses it) |
| \`secrets.CLAUDE_CODE_TOKEN\` | **NOT set yet**. \`claude-on-label.yml\` will exit loudly with a setup-instruction error until you run \`gh secret set CLAUDE_CODE_TOKEN --repo jeswr/noir_IEEE754\` |
| Routine \`trig_01Ww6Q1N6VKRUta4a649Ujm7\` | enabled |

## Backfill — what I did to clear the existing labelled PRs

Fired the routine on demand via the claude.ai/code API. It will process #60 and #86 per their thread state, and #87 will get a triage-only comment (it's in the Tier-4 DO-NOT-TOUCH set per the routine prompt).

## Test plan

After this PR merges + you set \`CLAUDE_CODE_TOKEN\`:

- [ ] Push a tiny commit to a PR with unresolved Copilot threads, dismiss + re-request Copilot review (or just push to refire the gate). \`require-copilot-review.yml\` runs → applies label using \`GH_TOKEN\` → \`claude-on-label.yml\` fires → routine dispatches.
- [ ] Verify in Actions tab that \`Dispatch Claude routine on address-review-comments label\` workflow shows a successful run after the label is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)