### PR TITLE
chore: first face re-sync since transfer — #1558 underflow fix + full drift

### DIFF
--- a/src/lib.nr
+++ b/src/lib.nr
@@ -120,6 +120,58 @@ fn arithmetic_scales_across_generated_float_widths() {
 	assert_eq((quad_two / quad_two).bits(), 0x3fff0000000000000000000000000000 as u128);
 }
 
+// Regression: binary128 mul/div on deep-underflow inputs must return a
+// correctly-signed zero per IEEE 754-2019 section 7.5, NOT abort the circuit on
+// an unsigned exponent underflow (sq-25mgo). Oracle: exact-rational binary128
+// soft-float (round-nearest-even), cross-checked with an exact-fraction script -
+// a power-of-two / clearly-below-half-ULP product rounds to +/-0 with the XOR sign.
+//   smallest_subnormal = 2^-16494  (0x...0001)
+//   max_finite         = (2 - 2^-112) * 2^16383  (exponent 0x7ffe, mantissa all-ones)
+#[test]
+fn f128_mul_deep_underflow_returns_signed_zero() {
+	let smallest_subnormal = f128::new(0x00000000000000000000000000000001 as u128);
+	let neg_smallest_subnormal = f128::new(0x80000000000000000000000000000001 as u128);
+
+	// smallest_subnormal^2 = 2^-32988 << half-ULP(2^-16494) -> +0 (repro case 1).
+	assert_eq((smallest_subnormal * smallest_subnormal).bits(), 0x00000000000000000000000000000000 as u128);
+	// Sign is the XOR of operand signs even when the magnitude underflows to zero.
+	assert_eq((smallest_subnormal * neg_smallest_subnormal).bits(), 0x80000000000000000000000000000000 as u128);
+	assert_eq((neg_smallest_subnormal * smallest_subnormal).bits(), 0x80000000000000000000000000000000 as u128);
+	assert_eq((neg_smallest_subnormal * neg_smallest_subnormal).bits(), 0x00000000000000000000000000000000 as u128);
+}
+
+#[test]
+fn f128_div_deep_underflow_returns_signed_zero() {
+	let min_sub = f128::new(0x00000000000000000000000000000001 as u128);
+	let neg_min_sub = f128::new(0x80000000000000000000000000000001 as u128);
+	let max_finite = f128::new(0x7ffeffffffffffffffffffffffffffff as u128);
+	let neg_max_finite = f128::new(0xfffeffffffffffffffffffffffffffff as u128);
+
+	// min_sub / max_finite = 2^-16494 / ~2^16384 = 2^-32878 << half-ULP -> +0 (repro case 2).
+	assert_eq((min_sub / max_finite).bits(), 0x00000000000000000000000000000000 as u128);
+	assert_eq((neg_min_sub / max_finite).bits(), 0x80000000000000000000000000000000 as u128);
+	assert_eq((min_sub / neg_max_finite).bits(), 0x80000000000000000000000000000000 as u128);
+	assert_eq((neg_min_sub / neg_max_finite).bits(), 0x00000000000000000000000000000000 as u128);
+}
+
+// Anti-over-saturation guard: results that are genuine subnormals must stay
+// subnormal, not be flushed to zero by the underflow-safe exponent clamp.
+// Oracle (exact rational): 2^-16382 * 2^-112 = 2^-16494 = smallest subnormal;
+// 2^-16382 / 2 = 2^-16383 = subnormal with mantissa 2^111.
+#[test]
+fn f128_arithmetic_preserves_gradual_underflow_subnormals() {
+	let smallest_normal = f128::new(0x00010000000000000000000000000000 as u128); // 2^-16382
+	let pow2_neg_112 = f128::new(0x3f8f0000000000000000000000000000 as u128);     // 2^-112
+	let two = f128::new(0x40000000000000000000000000000000 as u128);
+	let half = f128::new(0x3ffe0000000000000000000000000000 as u128);            // 2^-1
+
+	// Multiplying down to the exact smallest subnormal (one ULP above zero).
+	assert_eq((smallest_normal * pow2_neg_112).bits(), 0x00000000000000000000000000000001 as u128);
+	// Dividing into the subnormal range (2^-16383, mantissa bit 2^111 set).
+	assert_eq((smallest_normal / two).bits(), 0x00008000000000000000000000000000 as u128);
+	assert_eq((smallest_normal * half).bits(), 0x00008000000000000000000000000000 as u128);
+}
+
 #[test]
 fn unsigned_integer_conversions_follow_ieee_rounding() {
 	assert_eq(f16::from(0 as u8).bits(), 0x0000 as u16);

--- a/src/ops/kernels.nr
+++ b/src/ops/kernels.nr
@@ -13,6 +13,29 @@ fn exponent_offset() -> u16 {
     32768_u16
 }
 
+/// Underflow-safe biased-exponent subtraction for mul/div (sq-25mgo).
+///
+/// The internal work exponent lives in an offset domain (`offset + true_exp`).
+/// A deep-underflow product/quotient can drive `sum - subtrahend` below zero,
+/// which is not representable as a `u16` and would abort the circuit on an
+/// unsigned underflow (an unprovable constraint) instead of yielding the
+/// correctly-signed zero required by IEEE 754-2019 section 7.5. Widen the
+/// operands to `u32` and saturate the result's lower bound at 0.
+///
+/// Saturating at 0 never flushes a legitimate subnormal: any representable
+/// (sub)normal result has a work exponent far above `offset` (the smallest
+/// subnormal work exponent is ~offset/2 for every supported format), so the
+/// `sum <= subtrahend` branch is only ever reached by inputs whose true result
+/// is orders of magnitude below the smallest subnormal. `round_pack_normalized`
+/// then flushes the 0-exponent significand to a signed zero.
+fn saturating_biased_exponent(sum: u32, subtrahend: u32) -> u16 {
+    if sum > subtrahend {
+        (sum - subtrahend) as u16
+    } else {
+        0_u16
+    }
+}
+
 fn hidden_bit() -> u128 {
     hidden_bit_typed::<u128>(112_u8)
 }
@@ -757,7 +780,12 @@ pub(crate) fn mul_wide(
     } else {
         let (left_significand, left_exponent) = normalized_finite(left);
         let (right_significand, right_exponent) = normalized_finite(right);
-        let mut result_exponent = ((left_exponent as u32) + (right_exponent as u32) - (exponent_offset() as u32)) as u16;
+        // sq-25mgo: saturate the deep-underflow product exponent at 0 (see
+        // `saturating_biased_exponent`) instead of aborting on a u16 underflow.
+        let mut result_exponent = saturating_biased_exponent(
+            (left_exponent as u32) + (right_exponent as u32),
+            exponent_offset() as u32,
+        );
         let divisor = (1 as u128) << 109;
         let product = (left_significand as Field) * (right_significand as Field);
         // Safety: the product reconstruction and strict-remainder complement pin the split.
@@ -796,14 +824,20 @@ pub(crate) fn div_wide(
     } else if right_infinite | left_zero {
         zero_parts(result_sign)
     } else {
-        let (mut left_significand, mut result_exponent) = normalized_finite(left);
+        let (mut left_significand, left_work_exponent) = normalized_finite(left);
         let (right_significand, right_exponent) = normalized_finite(right);
-        result_exponent = ((result_exponent as u32) + (exponent_offset() as u32) - (right_exponent as u32)) as u16;
 
-        if less_than_u128_bounded::<112>(left_significand, right_significand) {
+        let needs_shift = less_than_u128_bounded::<112>(left_significand, right_significand);
+        if needs_shift {
             left_significand = left_significand * 2;
-            result_exponent = result_exponent - 1;
         }
+        // sq-25mgo: fold the pre-scale decrement into the subtrahend and saturate
+        // the deep-underflow quotient exponent at 0 (see `saturating_biased_exponent`)
+        // instead of aborting on a u16 underflow.
+        let result_exponent = saturating_biased_exponent(
+            (left_work_exponent as u32) + (exponent_offset() as u32),
+            (right_exponent as u32) + (needs_shift as u32),
+        );
 
         // Safety: reconstruction and the strict-remainder complement pin the unique split.
         let (quotient, remainder): (u128, u128) = unsafe {
@@ -1374,7 +1408,13 @@ where
     } else {
         let (left_significand, left_exponent) = normalized_finite_u64::<EXPONENT_BITS, MANTISSA_BITS>(left_work);
         let (right_significand, right_exponent) = normalized_finite_u64::<EXPONENT_BITS, MANTISSA_BITS>(right_work);
-        let mut result_exponent = ((left_exponent as u32) + (right_exponent as u32) - (exponent_offset() as u32)) as u16;
+        // sq-25mgo: the narrow-format work exponents cluster near `offset`, so this
+        // sum cannot underflow today, but apply the same underflow-safe idiom
+        // defensively (identical semantics on every representable input).
+        let mut result_exponent = saturating_biased_exponent(
+            (left_exponent as u32) + (right_exponent as u32),
+            exponent_offset() as u32,
+        );
         let hidden = hidden_bit_u64(MANTISSA_BITS);
         let product = (left_significand as Field) * (right_significand as Field);
         let overflow_threshold = (hidden as Field) * (hidden as Field) * 2;
@@ -1439,13 +1479,18 @@ where
     } else if right_infinite | left_zero {
         zero_parts_u64(result_sign)
     } else {
-        let (mut left_significand, mut result_exponent) = normalized_finite_u64::<EXPONENT_BITS, MANTISSA_BITS>(left_work);
+        let (mut left_significand, left_work_exponent) = normalized_finite_u64::<EXPONENT_BITS, MANTISSA_BITS>(left_work);
         let (right_significand, right_exponent) = normalized_finite_u64::<EXPONENT_BITS, MANTISSA_BITS>(right_work);
-        result_exponent = ((result_exponent as u32) + (exponent_offset() as u32) - (right_exponent as u32)) as u16;
 
         let needs_shift = left_significand < right_significand;
         left_significand = left_significand * (1 + (needs_shift as u64));
-        result_exponent = result_exponent - (needs_shift as u16);
+        // sq-25mgo: fold the pre-scale decrement into the subtrahend and apply the
+        // underflow-safe saturating idiom defensively (narrow work exponents cannot
+        // underflow today; identical semantics on every representable input).
+        let result_exponent = saturating_biased_exponent(
+            (left_work_exponent as u32) + (exponent_offset() as u32),
+            (right_exponent as u32) + (needs_shift as u32),
+        );
 
         // Safety: reconstruction and typed remainder comparison pin the unique split.
         let (quotient, remainder): (u64, u64) = unsafe {


### PR DESCRIPTION
> 🤖 **SPARQ agent** — FIRST face re-sync of noir_IEEE754 since its transfer to sparq-org (bead sq-ev2hm). Ports drift from sparq PR #1558 (kernels.nr underflow fix + lib.nr regression tests) plus all accumulated drift since transfer. Nargo 1.0.0-beta.21 tests: 32/32 in-source tests passing (up from 29 at transfer time, +3 new underflow regression tests). (Pattern per sq-egw8o/sq-tlu1z prior art.)

## Summary

Full recursive diff between `sparq-org/sparq:zk/ieee754/` (canonical in-tree source) and this standalone repo. Only the Noir source files had drift — from sparq PR #1558 "fix(zk/ieee754): f128 mul/div flush deep-underflow to signed zero".

### Changes ported

**`src/ops/kernels.nr`** — adds `saturating_biased_exponent(sum: u32, subtrahend: u32) -> u16` helper and applies it in three call sites (f128 mul kernel, f128 div kernel, narrow-format mul/div kernels). This replaces unsafe `as u16` truncating subtraction with a saturating variant that correctly returns zero instead of aborting on a unsigned underflow when the true result is a deep-underflow zero (IEEE 754-2019 §7.5, sq-25mgo).

**`src/lib.nr`** — adds three regression tests:
- `f128_mul_deep_underflow_returns_signed_zero` — verifies sign-correct zero for `smallest_subnormal²` and cross-sign variants
- `f128_div_deep_underflow_returns_signed_zero` — verifies sign-correct zero for `min_sub / max_finite` and cross-sign variants  
- `f128_arithmetic_preserves_gradual_underflow_subnormals` — anti-over-saturation guard: legitimate subnormals must not be flushed to zero

**`README.md`** — intentionally kept as standalone published-face content (in-tree README has old vendoring provenance text; standalone README is correct).

## Test plan

- [x] `nargo test --silence-warnings` → 32/32 in-source tests pass (Nargo 1.0.0-beta.21)
- [x] Zero byte diff remaining between in-tree source `.nr` files and this repo after porting
- [x] CI workflow will run in-source tests + generated arithmetic vectors + public API surface checks