### PR TITLE
ci: differential oracle lane, test-summary aggregator, copilot-review-posted producer, version 0.10.0 (sq-5reoy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@
 # than the upstream `install` helper — that helper curls noirup from
 # `releases/latest`, a moving target that defeats the pin. `noirup --version`
 # then installs the EXACT NARGO_VERSION. GitHub Actions are SHA-pinned.
+#
+# JOBS:
+#   test        — nargo unit tests + generated vectors + API surface + lint
+#   differential — drift-guard committed oracle + run full harness + self-test
+#   test-summary — aggregator: required context for branch protection ruleset
+#                  (11111001). Passes iff test + differential both passed.
 name: ci
 
 on:
@@ -27,6 +33,7 @@ env:
 
 jobs:
   test:
+    name: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -57,3 +64,101 @@ jobs:
 
       - name: Private-function usage lint
         run: python3 scripts/lint_private_function_usage.py
+
+  # [SONNET-4.6] sq-5reoy — IEEE 754 differential oracle lane (ported from
+  # sparq's zk-toolchain.yml differential-ieee754 job).
+  #
+  # Runs the Rust differential harness which:
+  #   1. Builds the standalone Rust binary (differential/).
+  #   2. Drift-guards the committed oracle (tests/differential_oracle/src/lib.nr)
+  #      against the generator — any stale file fails loudly.
+  #   3. Generates a fresh oracle Noir file and runs `nargo test` (24 test
+  #      functions, ~4500 assertions). Any divergence between the Noir circuit
+  #      and the oracle fails the gate.
+  #   4. SELF-TEST (inject-fault): re-generates with one expected bit flipped and
+  #      asserts `nargo test` FAILS — proving the harness is non-vacuous.
+  #
+  # TCB: oracle is INDEPENDENT of sparq_ieee754 — no shared code path with the circuit.
+  # This is VERIFICATION, not proof (ACIR->Barretenberg lowering NOT covered here).
+  differential:
+    name: differential oracle (PROOF M1)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache cargo + target (differential harness)
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: ieee754-differential
+          workspaces: differential -> target
+
+      - name: Install nargo (Noir) — pinned
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.nargo/bin"
+          curl -fsSL --proto '=https' --tlsv1.2 \
+            "${NOIRUP_BIN_URL}" \
+            -o "$HOME/.nargo/bin/noirup"
+          chmod +x "$HOME/.nargo/bin/noirup"
+          echo "$HOME/.nargo/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.nargo/bin:$PATH"
+          noirup --version "${NARGO_VERSION}"
+          nargo --version
+
+      # Drift guard: the generator (main.rs) must match the committed oracle file.
+      # Regenerate: bash scripts/run_differential_harness.sh --update-committed
+      - name: Drift guard — committed oracle matches generator
+        run: |
+          set -euo pipefail
+          cargo build --manifest-path differential/Cargo.toml --release --locked
+          HARNESS_BIN="differential/target/release/sparq-ieee754-differential"
+          COMMITTED="tests/differential_oracle/src/lib.nr"
+          TMPF="$(mktemp)"
+          trap 'rm -f "${TMPF}"' EXIT
+          "${HARNESS_BIN}" --output "${TMPF}"
+          diff "${TMPF}" "${COMMITTED}" || {
+            echo "ERROR: committed oracle is stale; regenerate with:" >&2
+            echo "  bash scripts/run_differential_harness.sh --update-committed" >&2
+            exit 1
+          }
+          echo "[drift-guard] committed oracle is current."
+
+      # Run the full differential harness including the inject-fault self-test.
+      # The script exits non-zero if:
+      #   a) the oracle nargo test fails (circuit diverges from oracle), or
+      #   b) the fault-injected nargo test PASSES (harness is vacuous/broken).
+      - name: Run ieee754 differential oracle + self-test
+        run: bash scripts/run_differential_harness.sh
+
+  # Aggregator — the required_status_checks context "test-summary" in ruleset 11111001
+  # points here. This job depends on ALL ci.yml jobs; it passes iff all predecessors
+  # passed (GitHub maps a skipped dependency to a passed aggregator only when the
+  # aggregator itself is not required — here it IS required, so we never skip it).
+  # [SONNET-4.6] sq-5reoy
+  test-summary:
+    name: test-summary
+    runs-on: ubuntu-latest
+    needs: [test, differential]
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
+          DIFFERENTIAL_RESULT: ${{ needs.differential.result }}
+        run: |
+          set -euo pipefail
+          echo "test:         ${TEST_RESULT}"
+          echo "differential: ${DIFFERENTIAL_RESULT}"
+          if [[ "${TEST_RESULT}" != "success" ]]; then
+            echo "::error::job 'test' did not succeed (result: ${TEST_RESULT})"
+            exit 1
+          fi
+          if [[ "${DIFFERENTIAL_RESULT}" != "success" ]]; then
+            echo "::error::job 'differential' did not succeed (result: ${DIFFERENTIAL_RESULT})"
+            exit 1
+          fi
+          echo "All CI jobs passed."

--- a/.github/workflows/copilot-review-posted.yml
+++ b/.github/workflows/copilot-review-posted.yml
@@ -1,0 +1,107 @@
+# copilot-review-posted — producer workflow for the "copilot-review-posted"
+# required status-check context in branch-protection ruleset 11111001.
+#
+# WHY: ruleset 11111001 requires the context "copilot-review-posted" as a
+# required_status_check. GitHub's native `copilot_code_review` rule requests
+# the review but does NOT post a commit status context by that name — so the
+# ruleset blocks every PR until a workflow does it explicitly.
+#
+# WHAT THIS DOES: whenever a pull_request_review is submitted (or a new push
+# arrives on a PR), this workflow checks whether GitHub Copilot
+# (copilot-pull-request-reviewer[bot]) has posted at least one review on the
+# PR. If it has, we POST a success commit status for "copilot-review-posted"
+# on the PR head SHA. If not (review not yet arrived, or bot was not requested),
+# we post a pending or failure status so the branch-protection rule stays
+# descriptive rather than silently blocked.
+#
+# TRIGGERS:
+#   pull_request_review (submitted) — fires when any review is submitted.
+#   pull_request (synchronize, opened, reopened) — re-evaluates after new
+#     pushes (a new commit might need a fresh Copilot review, so we re-check).
+#
+# PERMISSIONS:
+#   statuses: write — to POST commit statuses.
+#   pull-requests: read — to LIST reviews on the PR.
+#   contents: read  — default; needed by checkout-less API calls.
+#
+# SUPPLY-CHAIN: GitHub Actions are SHA-pinned per house style. No checkout
+# needed — the entire workflow runs via the GitHub CLI (gh) and the REST API.
+#
+# [SONNET-4.6] sq-5reoy / sq-umj0p fix
+name: copilot-review-posted
+
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  statuses: write
+  pull-requests: read
+  contents: read
+
+jobs:
+  post-status:
+    name: post copilot-review-posted status
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # No checkout needed — we only call the GitHub REST API.
+      - name: Check for Copilot review and post commit status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.review.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.review.commit_id }}
+        run: |
+          set -euo pipefail
+
+          echo "PR: #${PR_NUMBER}  HEAD SHA: ${HEAD_SHA}"
+          echo "Checking for Copilot review on PR #${PR_NUMBER}..."
+
+          # List all reviews on this PR and look for one by the Copilot bot.
+          # The bot's login is 'copilot-pull-request-reviewer[bot]'.
+          REVIEWS=$(gh api \
+            "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            --paginate \
+            --jq '[.[].user.login]')
+
+          echo "Reviewers found: ${REVIEWS}"
+
+          COPILOT_REVIEWED=$(echo "${REVIEWS}" | python3 -c "
+          import json, sys
+          reviews = json.load(sys.stdin)
+          found = any('copilot-pull-request-reviewer' in r for r in reviews)
+          print('true' if found else 'false')
+          ")
+
+          echo "copilot_reviewed=${COPILOT_REVIEWED}"
+
+          if [[ "${COPILOT_REVIEWED}" == "true" ]]; then
+            STATE="success"
+            DESCRIPTION="Copilot review has been posted."
+          else
+            # Post failure (not pending) so the ruleset shows a clear signal.
+            # The bot will post its review shortly after the PR opens/pushes;
+            # re-requesting Copilot review will re-trigger this workflow.
+            STATE="failure"
+            DESCRIPTION="Copilot review not yet posted. Request a Copilot review to unblock."
+          fi
+
+          echo "Posting commit status: context=copilot-review-posted state=${STATE}"
+          gh api \
+            --method POST \
+            "repos/${REPO}/statuses/${HEAD_SHA}" \
+            --field "state=${STATE}" \
+            --field "context=copilot-review-posted" \
+            --field "description=${DESCRIPTION}" \
+            --field "target_url=https://github.com/${REPO}/pull/${PR_NUMBER}"
+
+          echo "Status posted: ${STATE}"
+
+          # Exit non-zero so the workflow check itself reflects the status,
+          # but the REQUIRED context is what matters for branch protection —
+          # exit 0 always so the workflow check stays green even when we post
+          # a failure commit status (the commit status is the gate, not the
+          # workflow check-run).

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "sparq_ieee754"
+version = "0.10.0"
 type = "lib"
 authors = [""]
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated CI migration + release prep under maintainer directive sparq-org/sparq#1599 (bead sq-5reoy).

## Summary

- **`ci.yml` — `differential` job**: ports the `differential-ieee754` job from sparq's `zk-toolchain.yml` to the face repo. Builds the standalone Rust harness (`differential/`), drift-guards the committed oracle (`tests/differential_oracle/src/lib.nr` against the generator), runs the full oracle suite (24 test functions, ~4500 assertions), and runs the inject-fault self-test to prove the harness is non-vacuous. SHA-pinned actions, two-level nargo pin (noirup tagged release + pinned NARGO_VERSION), Swatinem cache.
- **`ci.yml` — `test-summary` aggregator**: adds a `test-summary` job (`needs: [test, differential]`, `if: always()`) that fails loudly if either predecessor did not succeed. This satisfies the ruleset-11111001 `required_status_checks` context `"test-summary"` which was previously phantom-unmet (no workflow produced it), hard-blocking every PR.
- **`copilot-review-posted.yml`**: new producer workflow. Triggers on `pull_request_review` (submitted) and `pull_request` (opened/synchronize/reopened). Queries the PR reviews API for `copilot-pull-request-reviewer[bot]` and POSTs a `success`/`failure` commit status with context `"copilot-review-posted"`. Fixes the sq-umj0p gap for noir_IEEE754 — the other required_status_checks context that was phantom-unmet.
- **`Nargo.toml`**: adds `version = "0.10.0"` — the first versioned release of the `sparq_ieee754` lineage (no `version` field existed in the pre-migration package).

## Bootstrap note

This PR itself will be hard-blocked by the ruleset until the `copilot-review-posted` producer is running and Copilot has reviewed it. **Admin bypass** is needed for this one bootstrap merge, exactly as surveyed. Once merged, all subsequent PRs will get the producer from the workflow itself.

## Test plan

- [ ] CI run for `test` job green (nargo tests + generated vectors + API surface + lint)
- [ ] CI run for `differential` job green (drift guard + oracle + self-test)
- [ ] CI run for `test-summary` job green (aggregator reports success)
- [ ] `copilot-review-posted.yml` workflow appears in Actions tab
- [ ] After merge: tag v0.10.0 cut on main with release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)